### PR TITLE
Tweak job list states, selectable refresh interval

### DIFF
--- a/ui/src/components/JobList.tsx
+++ b/ui/src/components/JobList.tsx
@@ -223,7 +223,7 @@ const JobList = (props: JobListProps) => {
               aria-label="Account options"
             >
               <span className="flex w-36 flex-1 items-center justify-between text-left">
-                <span className="text-base block align-middle font-semibold">
+                <span className="block align-middle text-base font-semibold">
                   {stateFormatted}
                 </span>
                 <span

--- a/ui/src/components/RefreshPauser.tsx
+++ b/ui/src/components/RefreshPauser.tsx
@@ -1,24 +1,117 @@
-import { useRefreshSetting } from "@contexts/RefreshSettings.hook";
-import { ArrowPathIcon, PauseIcon } from "@heroicons/react/24/outline";
+import { PauseIcon } from "@heroicons/react/24/outline";
+import { useEffect, useState } from "react";
+import {
+  Label,
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from "@headlessui/react";
+import clsx from "clsx";
 
-export function RefreshPauser(_props: React.ComponentPropsWithoutRef<"div">) {
-  const { disabled, setDisabled } = useRefreshSetting();
+import { useRefreshSetting } from "@contexts/RefreshSettings.hook";
+import { ArrowPathIcon } from "@heroicons/react/20/solid";
+
+type RefreshIntervalSetting = {
+  name: string;
+  value: number;
+};
+
+const refreshIntervals: RefreshIntervalSetting[] = [
+  { name: "Pause", value: 0 },
+  { name: "2s", value: 2000 },
+  { name: "5s", value: 5000 },
+  { name: "10s", value: 10000 },
+  { name: "30s", value: 30000 },
+  { name: "60s", value: 60000 },
+];
+
+export function RefreshPauser(
+  props: React.ComponentPropsWithoutRef<
+    typeof Listbox<"div", RefreshIntervalSetting>
+  >
+) {
+  const { intervalMs, setIntervalMs } = useRefreshSetting();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <div className="size-6" />;
+  }
+
+  const disabled = intervalMs === 0;
+  const selectedInterval =
+    refreshIntervals.find((i) => i.value === intervalMs) ??
+    ({ name: "Custom", value: intervalMs } as RefreshIntervalSetting);
 
   return (
-    <button
-      type="button"
-      className="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500"
-      onClick={() => setDisabled(!disabled)}
-      title={disabled ? "Resume live updates" : "Pause live updates"}
+    <Listbox
+      as="div"
+      value={selectedInterval}
+      by="value"
+      onChange={(newInterval) => setIntervalMs(newInterval.value)}
+      {...props}
     >
-      <span className="sr-only">
-        {disabled ? "Resume live updates" : "Pause live updates"}
-      </span>
-      {disabled ? (
-        <ArrowPathIcon className="size-6" aria-hidden="true" />
-      ) : (
-        <PauseIcon className="size-6" aria-hidden="true" />
-      )}
-    </button>
+      <Label className="sr-only">
+        {" "}
+        {disabled ? "Resume live updates" : "Pause live updates"}{" "}
+      </Label>
+      <ListboxButton
+        className="relative z-10 flex size-7 items-center justify-center rounded-lg text-slate-700 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+        aria-label="Theme"
+        // type="button"
+        // className="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500"
+        // onClick={() => setDisabled(!disabled)}
+        // title={disabled ? "Resume live updates" : "Pause live updates"}
+      >
+        <span className="sr-only">
+          {disabled ? "Resume live updates" : "Pause live updates"}
+        </span>
+        {disabled ? (
+          <PauseIcon className="size-6 text-slate-400" aria-hidden="true" />
+        ) : (
+          <ArrowPathIcon
+            className="size-6 text-slate-400 motion-safe:animate-spin-50-50"
+            aria-hidden="true"
+          />
+        )}
+      </ListboxButton>
+      <ListboxOptions className="absolute right-0 top-full mt-3 w-32 space-y-1 rounded-xl bg-white p-3 text-sm font-medium shadow-md shadow-black/5 ring-1 ring-black/5 dark:bg-slate-800 dark:ring-white/5">
+        <div className="px-2 text-xs font-semibold leading-6 text-slate-500">
+          Live Updates
+        </div>
+        {refreshIntervals.map((intervalSetting) => (
+          <ListboxOption
+            key={intervalSetting.value}
+            value={intervalSetting}
+            className={({ focus, selected }) =>
+              clsx(
+                "flex cursor-pointer select-none rounded-[0.625rem] px-2 py-1",
+                {
+                  "text-blue-600 dark:text-blue-400": selected,
+                  "text-slate-900 dark:text-white": focus && !selected,
+                  "text-slate-700 dark:text-slate-300": !focus && !selected,
+                  "bg-slate-100 dark:bg-slate-700": focus,
+                }
+              )
+            }
+          >
+            {({ selected }) => (
+              <div
+                className={clsx({
+                  "text-blue-600 dark:text-blue-400": selected,
+                  "text-slate-600 dark:text-slate-300": !selected,
+                })}
+              >
+                {intervalSetting.name}
+              </div>
+            )}
+          </ListboxOption>
+        ))}
+      </ListboxOptions>
+    </Listbox>
   );
 }

--- a/ui/src/components/ThemeSelector.tsx
+++ b/ui/src/components/ThemeSelector.tsx
@@ -90,14 +90,14 @@ export function ThemeSelector(
           <ListboxOption
             key={theme.value}
             value={theme.value}
-            className={({ active, selected }) =>
+            className={({ focus, selected }) =>
               clsx(
                 "flex cursor-pointer select-none items-center rounded-[0.625rem] p-1",
                 {
-                  "text-brand-primary dark:text-blue-400": selected,
-                  "text-slate-900 dark:text-white": active && !selected,
-                  "text-slate-700 dark:text-slate-300": !active && !selected,
-                  "bg-slate-100 dark:bg-slate-900/40": active,
+                  "text-blue-600 dark:text-blue-400": selected,
+                  "text-slate-900 dark:text-white": focus && !selected,
+                  "text-slate-700 dark:text-slate-300": !focus && !selected,
+                  "bg-slate-100 dark:bg-slate-700": focus,
                 }
               )
             }
@@ -109,8 +109,8 @@ export function ThemeSelector(
                     className={clsx(
                       "size-4",
                       selected
-                        ? "fill-sky-400 dark:fill-sky-400"
-                        : "fill-slate-400"
+                        ? "fill-blue-600 dark:fill-blue-400"
+                        : "fill-slate-600 dark:fill-slate-400"
                     )}
                   />
                 </div>

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -37,7 +37,7 @@ const TopNav = ({ children }: TopNavProps) => {
               className="hidden lg:block lg:h-6 lg:w-px lg:bg-slate-200 dark:lg:bg-slate-700"
               aria-hidden="true"
             />
-            <RefreshPauser />
+            <RefreshPauser className="relative z-10" />
             <ThemeSelector className="relative z-10" />
           </div>
         </div>

--- a/ui/src/contexts/RefreshSettings.hook.tsx
+++ b/ui/src/contexts/RefreshSettings.hook.tsx
@@ -5,9 +5,7 @@ import {
 } from "./RefreshSettings";
 
 const defaultContext: UseRefreshSettingProps = {
-  disabled: false,
   intervalMs: 2000,
-  setDisabled: () => {},
   setIntervalMs: () => {},
 };
 

--- a/ui/src/contexts/RefreshSettings.tsx
+++ b/ui/src/contexts/RefreshSettings.tsx
@@ -1,12 +1,9 @@
 import { Fragment, createContext, useContext, useMemo, useState } from "react";
 
 export interface UseRefreshSettingProps {
-  disabled: boolean;
   /** List of all available theme names */
   intervalMs: number;
-  /** Update the disabled setting */
-  setDisabled: React.Dispatch<React.SetStateAction<boolean>>;
-  /** Update the interval setting */
+  /** Update the interval setting. Set to 0 to disable refresh. */
   setIntervalMs: React.Dispatch<React.SetStateAction<number>>;
 }
 
@@ -31,17 +28,14 @@ export const RefreshSettingProvider: React.FC<RefreshSettingProviderProps> = (
 const RefreshSetting: React.FC<RefreshSettingProviderProps> = ({
   children,
 }) => {
-  const [disabled, setDisabled] = useState(false);
   const [intervalMs, setIntervalMs] = useState(2000);
 
   const providerValue = useMemo(
     () => ({
-      disabled,
       intervalMs,
-      setDisabled,
       setIntervalMs,
     }),
-    [disabled, intervalMs, setDisabled, setIntervalMs]
+    [intervalMs, setIntervalMs]
   );
 
   return (

--- a/ui/src/routes/jobs/$jobId.tsx
+++ b/ui/src/routes/jobs/$jobId.tsx
@@ -39,9 +39,7 @@ function JobComponent() {
   const { jobId } = Route.useParams();
   const { queryOptions } = Route.useRouteContext();
   const refreshSettings = useRefreshSetting();
-  queryOptions.refetchInterval = !refreshSettings.disabled
-    ? refreshSettings.intervalMs
-    : 0;
+  queryOptions.refetchInterval = refreshSettings.intervalMs;
 
   const queryClient = useQueryClient();
   const jobQuery = useQuery(queryOptions);

--- a/ui/src/routes/jobs/index.tsx
+++ b/ui/src/routes/jobs/index.tsx
@@ -50,9 +50,7 @@ function JobsIndexComponent() {
   const navigate = Route.useNavigate();
   const { limit } = Route.useLoaderDeps();
   const refreshSettings = useRefreshSetting();
-  const refetchInterval = !refreshSettings.disabled
-    ? refreshSettings.intervalMs
-    : 0;
+  const refetchInterval = refreshSettings.intervalMs;
 
   const jobsQuery = useSuspenseQuery(
     jobsQueryOptions(Route.useLoaderDeps(), { refetchInterval })

--- a/ui/src/routes/queues/$name.tsx
+++ b/ui/src/routes/queues/$name.tsx
@@ -40,9 +40,7 @@ function QueueComponent() {
   const { name } = Route.useParams();
   const { queryOptions } = Route.useRouteContext();
   const refreshSettings = useRefreshSetting();
-  queryOptions.refetchInterval = !refreshSettings.disabled
-    ? refreshSettings.intervalMs
-    : 0;
+  queryOptions.refetchInterval = refreshSettings.intervalMs;
 
   const queueQuery = useQuery(queryOptions);
   const { data: queue } = queueQuery;

--- a/ui/src/routes/queues/index.tsx
+++ b/ui/src/routes/queues/index.tsx
@@ -31,9 +31,7 @@ export const Route = createFileRoute("/queues/")({
 function QueuesIndexComponent() {
   const { queryOptions } = Route.useRouteContext();
   const refreshSettings = useRefreshSetting();
-  queryOptions.refetchInterval = !refreshSettings.disabled
-    ? refreshSettings.intervalMs
-    : 0;
+  queryOptions.refetchInterval = refreshSettings.intervalMs;
 
   const queryClient = useQueryClient();
 

--- a/ui/src/routes/workflows/$workflowId.tsx
+++ b/ui/src/routes/workflows/$workflowId.tsx
@@ -38,9 +38,7 @@ export const Route = createFileRoute("/workflows/$workflowId")({
 function WorkflowComponent() {
   const { queryOptions } = Route.useRouteContext();
   const refreshSettings = useRefreshSetting();
-  queryOptions.refetchInterval = !refreshSettings.disabled
-    ? refreshSettings.intervalMs
-    : 0;
+  queryOptions.refetchInterval = refreshSettings.intervalMs;
 
   const workflowQuery = useQuery(queryOptions);
 

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -8,11 +8,29 @@ export default {
   darkMode: "class",
   theme: {
     extend: {
+      animation: {
+        "spin-slow": "spin 3s linear infinite",
+        "spin-50-50": "pausingSpin 6s infinite",
+      },
       colors: {
         "brand-primary": "rgb(37, 99, 235)",
       },
       fontFamily: {
         sans: ["Inter var", ...defaultTheme.fontFamily.sans],
+      },
+      keyframes: {
+        pausingSpin: {
+          "0%": {
+            transform: "rotate(0)",
+            animationTimingFunction: "ease-in-out",
+          },
+          "42%,50%": { transform: "rotate(180deg)" },
+          "50%": {
+            transform: "rotate(180deg)",
+            animationTimingFunction: "ease-in-out",
+          },
+          "92%,100%": { transform: "rotate(360deg)" },
+        },
       },
     },
   },


### PR DESCRIPTION
### Mobile job state selector

| Before | After |
| - | - |
| ![](https://private-user-images.githubusercontent.com/114033/331444862-6215d5dd-bc7e-4a30-90eb-cfd7ade5f1de.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTYyMTY0MTQsIm5iZiI6MTcxNjIxNjExNCwicGF0aCI6Ii8xMTQwMzMvMzMxNDQ0ODYyLTYyMTVkNWRkLWJjN2UtNGEzMC05MGViLWNmZDdhZGU1ZjFkZS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNTIwJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDUyMFQxNDQxNTRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02MGU0YjkzYzFhYTI5ODM0ZjE2M2FmNTBmMWEwYzAzMjFhNmVlNjMxZGNjNTgwMTJlMjgzZDE2MDE0ZjkzNWFjJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.KzvLcsGhASBQzwFhggqz9TbXPAFhQCNSr3TF6Mp-mhI) | ![localhost_5173_jobs_state=running(iPhone SE)](https://github.com/riverqueue/riverui/assets/114033/49d84fb8-3af7-462f-adee-3518ac963fb9) |

### Refresh update customization

Before, it was just a pause/resume button. Now, there's a menu with selectable refresh intervals. I also aligned this and the theme selector menu's styling.

| light | dark |
| - | - |
| ![localhost_5173_jobs_state=running (1)](https://github.com/riverqueue/riverui/assets/114033/d2a13f0c-3cd5-4364-9868-efb572a3fed8) | ![localhost_5173_jobs_state=running](https://github.com/riverqueue/riverui/assets/114033/d6a875a6-55b9-406b-a2d2-353c494d85da) |
