### PR TITLE
expose http.Handler, move main to cmd/riverui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
 .env.*
 !.env.example
-riverui
-
+/riverui

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
 # syntax=docker/dockerfile:1
+
+# PATH_PREFIX for configuring the frontend's path prefix
+ARG PATH_PREFIX="/"
+
 FROM node:20-alpine AS build-ui
 WORKDIR /app
 COPY ui/package.json ui/package-lock.json ./
 RUN npm install
 ENV NODE_ENV=production
 COPY ui/ .
+ARG PATH_PREFIX
+# The URL (potentially relative) of the riverui API server to use. Defaults to
+# /api if unset:
 ARG VITE_RIVER_API_BASE_URL
-RUN npm exec vite build
+
+RUN CLEAN_PATH_PREFIX=$(echo $PATH_PREFIX | sed 's:/$::') && \
+  VITE_RIVER_API_BASE_URL=${VITE_RIVER_API_BASE_URL:-${CLEAN_PATH_PREFIX}/api} && \
+  export VITE_RIVER_API_BASE_URL && \
+  npx vite build --base=${PATH_PREFIX}
 
 # Build the Go binary, including embedded UI files:
 FROM golang:1.22.2-alpine AS build-go
@@ -16,13 +27,16 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Copy Go files without copying the ui dir:
-COPY *.go ./
+COPY *.go internal ./
+COPY cmd/ cmd/
 COPY internal/ internal/
 COPY ui/*.go ./ui/
 COPY --from=build-ui /app/dist ./ui/dist
 
-RUN go build -o /bin/riverui .
+RUN go build -o /bin/riverui ./cmd/riverui
 
 FROM alpine:3.19.1
+ARG PATH_PREFIX
+ENV PATH_PREFIX=${PATH_PREFIX}
 COPY --from=build-go /bin/riverui /bin/riverui
-CMD ["/bin/riverui"]
+CMD /bin/riverui -prefix=$PATH_PREFIX

--- a/api_handler.go
+++ b/api_handler.go
@@ -1,4 +1,4 @@
-package main
+package riverui
 
 import (
 	"context"
@@ -26,6 +26,7 @@ type jobCancelRequest struct {
 type apiHandler struct {
 	client  *river.Client[pgx.Tx]
 	dbPool  *pgxpool.Pool
+	logger  *slog.Logger
 	queries *db.Queries
 }
 
@@ -64,12 +65,12 @@ func (a *apiHandler) JobCancel(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// TODO: return jobs in response, use in frontend instead of invalidating
-	writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
+	a.writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
 }
 
-func writeResponse(ctx context.Context, rw http.ResponseWriter, data []byte) {
+func (a *apiHandler) writeResponse(ctx context.Context, rw http.ResponseWriter, data []byte) {
 	if _, err := rw.Write(data); err != nil {
-		logger.ErrorContext(ctx, "error writing response", slog.String("error", err.Error()))
+		a.logger.ErrorContext(ctx, "error writing response", slog.String("error", err.Error()))
 	}
 }
 
@@ -125,7 +126,7 @@ func (a *apiHandler) JobDelete(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	writeResponse(ctx, rw, []byte("{\"status\": \"ok\", \"num_deleted\": "+strconv.Itoa(numDeleted)+"}"))
+	a.writeResponse(ctx, rw, []byte("{\"status\": \"ok\", \"num_deleted\": "+strconv.Itoa(numDeleted)+"}"))
 }
 
 type jobRetryRequest struct {
@@ -162,7 +163,7 @@ func (a *apiHandler) JobRetry(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
+	a.writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
 }
 
 func (a *apiHandler) JobGet(rw http.ResponseWriter, req *http.Request) {
@@ -332,7 +333,7 @@ func (a *apiHandler) QueuePause(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
+	a.writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
 }
 
 func (a *apiHandler) QueueResume(rw http.ResponseWriter, req *http.Request) {
@@ -354,7 +355,7 @@ func (a *apiHandler) QueueResume(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
+	a.writeResponse(ctx, rw, []byte("{\"status\": \"ok\"}"))
 }
 
 func (a *apiHandler) StatesAndCounts(rw http.ResponseWriter, req *http.Request) {

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,185 @@
+package riverui
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/riverui/internal/db"
+	"github.com/riverqueue/riverui/ui"
+)
+
+// HandlerOpts are the options for creating a new Handler.
+type HandlerOpts struct {
+	// Client is the River client to use for API requests.
+	Client *river.Client[pgx.Tx]
+	// DBPool is the database connection pool to use for API requests.
+	DBPool *pgxpool.Pool
+	// Logger is the logger to use logging errors within the handler.
+	Logger *slog.Logger
+	// Prefix is the path prefix to use for the API and UI HTTP requests.
+	Prefix string
+}
+
+func (opts *HandlerOpts) validate() error {
+	if opts.Client == nil {
+		return errors.New("client is required")
+	}
+	if opts.DBPool == nil {
+		return errors.New("db pool is required")
+	}
+	if opts.Logger == nil {
+		return errors.New("logger is required")
+	}
+	opts.Prefix = normalizePathPrefix(opts.Prefix)
+	return nil
+}
+
+func normalizePathPrefix(prefix string) string {
+	if prefix == "" {
+		return "/"
+	}
+	prefix = strings.TrimSuffix(prefix, "/")
+	if !strings.HasPrefix(prefix, "/") {
+		return "/" + prefix
+	}
+	return prefix
+}
+
+// NewHandler creates a new http.Handler that serves the River UI and API.
+func NewHandler(opts *HandlerOpts) (http.Handler, error) {
+	if opts == nil {
+		return nil, errors.New("opts is required")
+	}
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	frontendIndex, err := fs.Sub(ui.Index, "dist")
+	if err != nil {
+		return nil, fmt.Errorf("error getting frontend index: %w", err)
+	}
+	httpFS := http.FS(frontendIndex)
+	fileServer := http.FileServer(httpFS)
+	serveIndex := serveFileContents("index.html", httpFS)
+
+	handler := &apiHandler{
+		client:  opts.Client,
+		dbPool:  opts.DBPool,
+		logger:  opts.Logger,
+		queries: db.New(opts.DBPool),
+	}
+	prefix := opts.Prefix
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/jobs", handler.JobList)
+	mux.HandleFunc("POST /api/jobs/cancel", handler.JobCancel)
+	mux.HandleFunc("POST /api/jobs/delete", handler.JobDelete)
+	mux.HandleFunc("POST /api/jobs/retry", handler.JobRetry)
+	mux.HandleFunc("GET /api/jobs/{id}", handler.JobGet)
+	mux.HandleFunc("GET /api/queues", handler.QueueList)
+	mux.HandleFunc("GET /api/queues/{name}", handler.QueueGet)
+	mux.HandleFunc("PUT /api/queues/{name}/pause", handler.QueuePause)
+	mux.HandleFunc("PUT /api/queues/{name}/resume", handler.QueueResume)
+	mux.HandleFunc("GET /api/workflows/{id}", handler.WorkflowGet)
+	mux.HandleFunc("GET /api/states", handler.StatesAndCounts)
+	mux.HandleFunc("/api", http.NotFound)
+	mux.Handle("/", intercept404(fileServer, serveIndex))
+
+	if prefix != "/" {
+		return stripPrefix(prefix, mux), nil
+	}
+	return mux, nil
+}
+
+// Go's http.StripPrefix can sometimes result in an empty path. For example,
+// when removing a prefix like "/foo" from path "/foo", the result is "".  This
+// does not get handled by the ServeMux correctly (it results in a redirect to
+// "/"). To avoid this, fork the StripPrefix implementation and ensure we never
+// return an empty path.
+func stripPrefix(prefix string, handler http.Handler) http.Handler {
+	if prefix == "" {
+		return handler
+	}
+	return http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		path := strings.TrimPrefix(request.URL.Path, prefix)
+		if path == "" {
+			path = "/"
+		}
+		rawPath := strings.TrimPrefix(request.URL.RawPath, prefix)
+		if rawPath == "" {
+			rawPath = "/"
+		}
+		if len(path) < len(request.URL.Path) && (request.URL.RawPath == "" || len(rawPath) < len(request.URL.RawPath)) {
+			request2 := new(http.Request)
+			*request2 = *request
+			request2.URL = new(url.URL)
+			*request2.URL = *request.URL
+			request2.URL.Path = path
+			request2.URL.RawPath = rawPath
+			redirectResponseWriter := &redirectPrefixResponseWriter{ResponseWriter: responseWriter, prefix: prefix}
+			handler.ServeHTTP(redirectResponseWriter, request2)
+		} else {
+			http.NotFound(responseWriter, request)
+		}
+	})
+}
+
+// redirectPrefixResponseWriter is required to correct the http.ServeMux behavior
+// with redirects that have no way of accounting for a path prefix. It intercepts
+// the exact usage of http.Redirect and corrects the Location header to include
+// the prefix, and rewrites the HTML response to include the prefixed link.
+//
+// There are no other redirects issued by this ServeMux so this is safe.
+type redirectPrefixResponseWriter struct {
+	http.ResponseWriter
+	code   int
+	prefix string
+}
+
+// Write corrects the HTML response for http.Redirect 301 redirect to include a
+// prefixed link.
+func (rw *redirectPrefixResponseWriter) Write(b []byte) (int, error) {
+	if rw.code != http.StatusMovedPermanently {
+		return rw.ResponseWriter.Write(b)
+	}
+
+	location := rw.Header().Get("Location")
+
+	body := "<a href=\"" + htmlEscape(location) + "\">" + http.StatusText(http.StatusMovedPermanently) + "</a>.\n"
+	return fmt.Fprintln(rw.ResponseWriter, body)
+}
+
+// WriteHeader corrects the Location header for http.Redirect 301 redirect to
+// include a prefixed URL.
+func (rw *redirectPrefixResponseWriter) WriteHeader(code int) {
+	rw.code = code
+	if code >= 300 && code < 400 {
+		if location := rw.Header().Get("Location"); location != "" {
+			rw.Header().Set("Location", rw.prefix+location)
+		}
+	}
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+var htmlReplacer = strings.NewReplacer( //nolint:gochecknoglobals
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+	// "&#34;" is shorter than "&quot;".
+	`"`, "&#34;",
+	// "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+	"'", "&#39;",
+)
+
+func htmlEscape(s string) string {
+	return htmlReplacer.Replace(s)
+}

--- a/spa_response_writer.go
+++ b/spa_response_writer.go
@@ -1,4 +1,4 @@
-package main
+package riverui
 
 import (
 	"fmt"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -47,7 +47,7 @@
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
-        "@vitejs/plugin-react-swc": "^3.3.2",
+        "@vitejs/plugin-react-swc": "^3.7.0",
         "autoprefixer": "^10.4.15",
         "eslint": "^8.45.0",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -59,8 +59,8 @@
         "storybook": "^8.0.10",
         "tailwindcss": "^3.3.5",
         "typescript": "^5.3.2",
-        "vite": "^5.0.4",
-        "vite-tsconfig-paths": "^4.2.1",
+        "vite": "^5.3.0",
+        "vite-tsconfig-paths": "^4.3.2",
         "vitest": "^1.2.2"
       }
     },
@@ -4700,14 +4700,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.3.tgz",
-      "integrity": "sha512-pSEglypnBGLHBoBcv3aYS7IM2t2LRinubYMyP88UoFIcD2pear2CeB15CbjJ2IzuvERD0ZL/bthM7cDSR9g+aQ==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.29.tgz",
+      "integrity": "sha512-nvTtHJI43DUSOAf3h9XsqYg8YXKc0/N4il9y4j0xAkO0ekgDNo+3+jbw6MInawjKJF9uulyr+f5bAutTsOKVlw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@swc/counter": "^0.1.2",
-        "@swc/types": "^0.1.5"
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.8"
       },
       "engines": {
         "node": ">=10"
@@ -4717,19 +4717,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.5.3",
-        "@swc/core-darwin-x64": "1.5.3",
-        "@swc/core-linux-arm-gnueabihf": "1.5.3",
-        "@swc/core-linux-arm64-gnu": "1.5.3",
-        "@swc/core-linux-arm64-musl": "1.5.3",
-        "@swc/core-linux-x64-gnu": "1.5.3",
-        "@swc/core-linux-x64-musl": "1.5.3",
-        "@swc/core-win32-arm64-msvc": "1.5.3",
-        "@swc/core-win32-ia32-msvc": "1.5.3",
-        "@swc/core-win32-x64-msvc": "1.5.3"
+        "@swc/core-darwin-arm64": "1.5.29",
+        "@swc/core-darwin-x64": "1.5.29",
+        "@swc/core-linux-arm-gnueabihf": "1.5.29",
+        "@swc/core-linux-arm64-gnu": "1.5.29",
+        "@swc/core-linux-arm64-musl": "1.5.29",
+        "@swc/core-linux-x64-gnu": "1.5.29",
+        "@swc/core-linux-x64-musl": "1.5.29",
+        "@swc/core-win32-arm64-msvc": "1.5.29",
+        "@swc/core-win32-ia32-msvc": "1.5.29",
+        "@swc/core-win32-x64-msvc": "1.5.29"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "*"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -4738,9 +4738,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.3.tgz",
-      "integrity": "sha512-kRmmV2XqWegzGXvJfVVOj10OXhLgaVOOBjaX3p3Aqg7Do5ksg+bY5wi1gAN/Eul7B08Oqf7GG7WJevjDQGWPOg==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.29.tgz",
+      "integrity": "sha512-6F/sSxpHaq3nzg2ADv9FHLi4Fu2A8w8vP8Ich8gIl16D2htStlwnaPmCLjRswO+cFkzgVqy/l01gzNGWd4DFqA==",
       "cpu": [
         "arm64"
       ],
@@ -4754,9 +4754,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.3.tgz",
-      "integrity": "sha512-EYs0+ovaRw6ZN9GBr2nIeC7gUXWA0q4RYR+Og3Vo0Qgv2Mt/XudF44A2lPK9X7M3JIfu6JjnxnTuvsK1Lqojfw==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.29.tgz",
+      "integrity": "sha512-rF/rXkvUOTdTIfoYbmszbSUGsCyvqACqy1VeP3nXONS+LxFl4bRmRcUTRrblL7IE5RTMCKUuPbqbQSE2hK7bqg==",
       "cpu": [
         "x64"
       ],
@@ -4770,9 +4770,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.3.tgz",
-      "integrity": "sha512-RBVUTidSf4wgPdv98VrgJ4rMzMDN/3LBWdT7l+R7mNFH+mtID7ZAhTON0o/m1HkECgAgi1xcbTOVAw1xgd5KLA==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.29.tgz",
+      "integrity": "sha512-2OAPL8iWBsmmwkjGXqvuUhbmmoLxS1xNXiMq87EsnCNMAKohGc7wJkdAOUL6J/YFpean/vwMWg64rJD4pycBeg==",
       "cpu": [
         "arm"
       ],
@@ -4786,9 +4786,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.3.tgz",
-      "integrity": "sha512-DCC6El3MiTYfv98CShxz/g2s4Pxn6tV0mldCQ0UdRqaN2ApUn7E+zTrqaj5bk7yII3A43WhE9Mr6wNPbXUeVyg==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.29.tgz",
+      "integrity": "sha512-eH/Q9+8O5qhSxMestZnhuS1xqQMr6M7SolZYxiXJqxArXYILLCF+nq2R9SxuMl0CfjHSpb6+hHPk/HXy54eIRA==",
       "cpu": [
         "arm64"
       ],
@@ -4802,9 +4802,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.3.tgz",
-      "integrity": "sha512-p04ysjYXEyaCGpJvwHm0T0nkPawXtdKBTThWnlh8M5jYULVNVA1YmC9azG2Avs1GDaLgBPVUgodmFYpdSupOYA==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.29.tgz",
+      "integrity": "sha512-TERh2OICAJz+SdDIK9+0GyTUwF6r4xDlFmpoiHKHrrD/Hh3u+6Zue0d7jQ/he/i80GDn4tJQkHlZys+RZL5UZg==",
       "cpu": [
         "arm64"
       ],
@@ -4818,9 +4818,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.3.tgz",
-      "integrity": "sha512-/l4KJu0xwYm6tcVSOvF8RbXrIeIHJAhWnKvuX4ZnYKFkON968kB8Ghx+1yqBQcZf36tMzSuZUC5xBUA9u66lGA==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.29.tgz",
+      "integrity": "sha512-WMDPqU7Ji9dJpA+Llek2p9t7pcy7Bob8ggPUvgsIlv3R/eesF9DIzSbrgl6j3EAEPB9LFdSafsgf6kT/qnvqFg==",
       "cpu": [
         "x64"
       ],
@@ -4834,9 +4834,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.3.tgz",
-      "integrity": "sha512-54DmSnrTXq4fYEKNR0nFAImG3+FxsHlQ6Tol/v3l+rxmg2K0FeeDOpH7wTXeWhMGhFlGrLIyLSnA+SzabfoDIA==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.29.tgz",
+      "integrity": "sha512-DO14glwpdKY4POSN0201OnGg1+ziaSVr6/RFzuSLggshwXeeyVORiHv3baj7NENhJhWhUy3NZlDsXLnRFkmhHQ==",
       "cpu": [
         "x64"
       ],
@@ -4850,9 +4850,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.3.tgz",
-      "integrity": "sha512-piUMqoHNwDXChBfaaFIMzYgoxepfd8Ci1uXXNVEnuiRKz3FiIcNLmvXaBD7lKUwKcnGgVziH/CrndX6SldKQNQ==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.29.tgz",
+      "integrity": "sha512-V3Y1+a1zG1zpYXUMqPIHEMEOd+rHoVnIpO/KTyFwAmKVu8v+/xPEVx/AGoYE67x4vDAAvPQrKI3Aokilqa5yVg==",
       "cpu": [
         "arm64"
       ],
@@ -4866,9 +4866,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.3.tgz",
-      "integrity": "sha512-zV5utPYBUzYhBOomCByAjKAvfVBcOCJtnszx7Zlfz7SAv/cGm8D1QzPDCvv6jDhIlUtLj6KyL8JXeFr+f95Fjw==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.29.tgz",
+      "integrity": "sha512-OrM6yfXw4wXhnVFosOJzarw0Fdz5Y0okgHfn9oFbTPJhoqxV5Rdmd6kXxWu2RiVKs6kGSJFZXHDeUq2w5rTIMg==",
       "cpu": [
         "ia32"
       ],
@@ -4882,9 +4882,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.3.tgz",
-      "integrity": "sha512-QmUiXiPIV5gBADfDh8e2jKynEhyRC+dcKP/zF9y5KqDUErYzlhocLd68uYS4uIegP6AylYlmigHgcaktGEE9VQ==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.29.tgz",
+      "integrity": "sha512-eD/gnxqKyZQQR0hR7TMkIlJ+nCF9dzYmVVNbYZWuA1Xy94aBPUsEk3Uw3oG7q6R3ErrEUPP0FNf2ztEnv+I+dw==",
       "cpu": [
         "x64"
       ],
@@ -4912,9 +4912,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
-      "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.8.tgz",
+      "integrity": "sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==",
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -6385,12 +6385,12 @@
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.6.0.tgz",
-      "integrity": "sha512-XFRbsGgpGxGzEV5i5+vRiro1bwcIaZDIdBRP16qwm+jP68ue/S8FJTBEgOeojtVDYrbSua3XFp71kC8VJE6v+g==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz",
+      "integrity": "sha512-yrknSb3Dci6svCd/qhHqhFPDSw0QtjumcqdKMoNNzmOl5lMXTTiqzjWtG4Qask2HdvvzaNgSunbQGet8/GrKdA==",
       "dev": true,
       "dependencies": {
-        "@swc/core": "^1.3.107"
+        "@swc/core": "^1.5.7"
       },
       "peerDependencies": {
         "vite": "^4 || ^5"
@@ -14536,12 +14536,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
-      "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.0.tgz",
+      "integrity": "sha512-hA6vAVK977NyW1Qw+fLvqSo7xDPej7von7C3DwwqPRmnnnK36XEBC/J3j1V5lP8fbt7y0TgTKJbpNGSwM+Bdeg==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.20.1",
+        "esbuild": "^0.21.3",
         "postcss": "^8.4.38",
         "rollup": "^4.13.0"
       },
@@ -14629,6 +14629,412 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/vitest": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
-    "@vitejs/plugin-react-swc": "^3.3.2",
+    "@vitejs/plugin-react-swc": "^3.7.0",
     "autoprefixer": "^10.4.15",
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
@@ -55,8 +55,8 @@
     "storybook": "^8.0.10",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.3.2",
-    "vite": "^5.0.4",
-    "vite-tsconfig-paths": "^4.2.1",
+    "vite": "^5.3.0",
+    "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.2.2"
   },
   "scripts": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,7 +13,11 @@ import { routeTree } from "./routeTree.gen";
 const queryClient = new QueryClient();
 
 // Create a new router instance
-const router = createRouter({ context: { queryClient }, routeTree });
+const router = createRouter({
+  basepath: import.meta.env.BASE_URL,
+  context: { queryClient },
+  routeTree,
+});
 
 // Register your router for maximum type safety
 declare module "@tanstack/react-router" {


### PR DESCRIPTION
This extracts the main executable to `cmd/riverui`, and extracts the
handler code to a `riverui.NewHandler()` function so that it can be
embedded like any other `http.Handler`.

As part of doing this, changes were made on both the Go and JS side to
facilitate running the frontend within a path prefix. Right now this is
a bit messy to take advantage of because the JS frontend needs to be
configured or built with the base path like so:

    VITE_RIVER_API_BASE_URL=/riverui/api ./node_modules/vite/bin/vite.js build --base="/riverui/"

Additionally `NewHandler()` needs to be provided with the base path so
that it can be stripped from incoming requests to the `ServeMux`.

The Dockerfile has also been reworked to make it easy to set a path prefix as
well as a custom API route as desired.

Fixes https://github.com/riverqueue/riverui/issues/21.