### PR TITLE
sticky bottom bar on job list

### DIFF
--- a/ui/src/components/JobList.tsx
+++ b/ui/src/components/JobList.tsx
@@ -144,14 +144,17 @@ const JobRows = ({
     return <EmptyState />;
   }
   return (
-    <div className="mx-auto px-4 sm:px-6 lg:px-8">
-      <ul role="list" className="divide-y divide-black/5 dark:divide-white/5">
+    <div className="px-4 sm:px-6 lg:px-8 min-h-dvh flex flex-col">
+      <ul
+        role="list"
+        className="divide-y divide-black/5 dark:divide-white/5 flex-grow"
+      >
         {jobs.map((job) => (
           <JobListItem key={job.id.toString()} job={job} />
         ))}
       </ul>
       <nav
-        className="flex items-center justify-center border-t border-black/5 py-3 dark:border-white/5"
+        className="flex items-center justify-center border-t border-black/5 py-3 dark:border-white/5 sticky bottom-0 left-0 right-0 bg-white dark:bg-slate-900"
         aria-label="Pagination"
       >
         <Button
@@ -203,7 +206,7 @@ const JobList = (props: JobListProps) => {
   );
 
   return (
-    <div className="h-full lg:pl-72">
+    <div className="lg:pl-72">
       <TopNav>
         <header className="flex flex-1 items-center lg:hidden">
           <h1 className="hidden text-base font-semibold leading-6 text-slate-900 dark:text-slate-100 lg:inline">
@@ -214,7 +217,7 @@ const JobList = (props: JobListProps) => {
               className="flex items-center gap-3 rounded-xl border border-transparent px-2 py-1 text-slate-700 data-[active]:border-slate-200 data-[hover]:border-slate-200 dark:text-slate-300 dark:data-[active]:border-slate-700 dark:data-[hover]:border-slate-700"
               aria-label="Account options"
             >
-              <span className="flex w-36 flex-1 items-center justify-between text-left">
+              <span className="flex min-w-36 flex-1 items-center justify-between text-left">
                 <span className="block align-middle text-base font-semibold">
                   {stateFormatted}
                 </span>

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -1,17 +1,17 @@
-import { PropsWithChildren } from "react";
+import { HTMLAttributes, PropsWithChildren } from "react";
 
 import { Bars3Icon } from "@heroicons/react/24/outline";
 import { RefreshPauser } from "@components/RefreshPauser";
 import { ThemeSelector } from "@components/ThemeSelector";
 import { useSidebarSetting } from "@contexts/SidebarSetting.hook";
 
-type TopNavProps = PropsWithChildren<object>;
+type TopNavProps = PropsWithChildren<HTMLAttributes<HTMLElement>>;
 
 const TopNav = ({ children }: TopNavProps) => {
   const { setOpen: setSidebarOpen } = useSidebarSetting();
 
   return (
-    <div className="sticky top-0 z-40 bg-white dark:border-slate-700 dark:bg-slate-900 lg:mx-auto">
+    <div className="sticky top-0 z-40 bg-white dark:border-slate-700 dark:bg-slate-900 lg:w-100">
       <div className="flex h-16 items-center gap-x-4 border-b  px-4 shadow-sm dark:border-slate-800 sm:gap-x-6 sm:px-6 lg:px-8 lg:shadow-none">
         <button
           type="button"


### PR DESCRIPTION
Instead of the bottom bar jumping around as the list grows, keep it fixed to the bottom of the screen. Tested on Chrome and Safari (both desktop + iOS). Tapping on top of screen on iOS also still works with scroll to top behavior.

| Short list | Long list |
| - | - |
| ![localhost_5173_jobs_state=completed(iPhone 14 Pro Max) (1)](https://github.com/riverqueue/riverui/assets/114033/e2141e2f-8295-4332-935c-b1bf04c83a63) | ![localhost_5173_jobs_state=completed(iPhone 14 Pro Max)](https://github.com/riverqueue/riverui/assets/114033/7bf0007b-35fc-4d10-8dc7-ec334014d3c8) |

Sorry for tanstack dev overlays, didn't feel like turning them off for these screenshots.

Fixes #28.