### PR TITLE
close sidebar after clicking a nav item (mobile)

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -136,6 +136,7 @@ const Layout = ({ children }: LayoutProps) => {
                                     className:
                                       "text-slate-600 dark:text-slate-400 dark:hover:text-white hover:text-slate-900 border-transparent dark:hover:bg-slate-800 hover:bg-slate-200",
                                   }}
+                                  onClick={() => setSidebarOpen(false)}
                                 >
                                   <item.icon
                                     className="size-6 shrink-0"


### PR DESCRIPTION
Noticed the sidebar on mobile wasn't closing after navigating to a new section. This fixes it.