### PR TITLE
Add `write` permission to release job's GitHub token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,6 +198,8 @@ jobs:
 
   release:
     name: Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
Follows up #39 with a small fix to add `write` permissions to the
release job's `GITHUB_TOKEN`, thereby allowing it to actually cut a new
release on the repository.