### PR TITLE
fix unhandled timeline scenario for retryable jobs

### DIFF
--- a/ui/src/components/JobTimeline.tsx
+++ b/ui/src/components/JobTimeline.tsx
@@ -139,6 +139,12 @@ const ScheduledStep = ({ job }: { job: Job }) => {
 };
 
 const WaitStep = ({ job }: { job: Job }) => {
+  const nowSec = useTime();
+  const scheduledAtInFuture = useMemo(
+    () => job.scheduledAt >= new Date(nowSec * 1000),
+    [job.scheduledAt, nowSec]
+  );
+
   if (job.state === JobState.Scheduled && !job.attemptedAt) {
     return (
       <StatusStep
@@ -147,6 +153,19 @@ const WaitStep = ({ job }: { job: Job }) => {
         description="—"
         status="pending"
       />
+    );
+  }
+
+  if (job.state === JobState.Retryable && scheduledAtInFuture) {
+    return (
+      <StatusStep
+        Icon={QueueListIcon}
+        name="Wait"
+        status="complete"
+        descriptionTitle={job.scheduledAt.toUTCString()}
+      >
+        –
+      </StatusStep>
     );
   }
 


### PR DESCRIPTION
The Wait step in the timeline attempts to show how long a job waited between its `scheduled_at` time and when it was picked up for work with `attempted_at`.

This works well for nearly all cases, but it doesn't work well for jobs that error and become `retryable` because those jobs overwrite the `scheduled_at` with the _new_ time for the next attempt, so there is no longer any way to deduce how long a job waited before being executed.

Longer term this is something I'd like to think about addressing with a new way of storing more details on individual job attempts so that no detail is lost along the way like this. But for now, the best we can do is detect this scenario and show some empty text instead of a nonsensical negative duration like this:

<img width="464" alt="Screenshot 2024-06-20 at 9 34 13 AM" src="https://github.com/riverqueue/riverui/assets/114033/6cd334d2-e98f-4dc0-be25-b814ab345828">
