### PR TITLE
Add install instructions to the README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Copy Go files without copying the ui dir:
-COPY *.go internal README.md LICENSE ./
+COPY *.go internal docs/README.md LICENSE ./
 COPY cmd/ cmd/
 COPY internal/ internal/
 COPY ui/*.go ./ui/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# River UI
+
+River UI is a graphical user interface for the [River job queue](https://github.com/riverqueue/river). It lets users view and manage jobs without having to resort to querying the database or the command line.
+
+## Installation
+
+A working River database is required for the UI to start up properly. See [running River migrations](https://riverqueue.com/docs/migrations), and make sure a `DATABASE_URL` is exported to env.
+
+```sh
+$ go install github.com/riverqueue/river/cmd/river@latest
+$ river migrate-up --database-url "$DATABASE_URL"
+```
+
+### From binary
+
+River UI [releases](https://github.com/riverqueue/riverui/releases) include a set of static binaries for a variety of architectures and operating systems. Fetch and run one with:
+
+```sh
+$ RIVER_ARCH=arm64 # either 'amd64' or 'arm64'
+$ RIVER_OS=darwin  # either 'darwin' or 'linux'
+$ curl -L https://github.com/riverqueue/riverui/releases/latest/download/riverui_${RIVER_OS}_${RIVER_ARCH}.gz | gzip -d > riverui
+$ chmod +x riverui
+$ ./riverui
+```
+
+### From container image
+
+River UI ships [container images](https://github.com/riverqueue/riverui/pkgs/container/riverui) with each release. Pull and run the latest with:
+
+```sh
+$ docker pull ghcr.io/riverqueue/riverui:latest
+$ docker run ghcr.io/riverqueue/riverui:latest
+```
+
+## Development
+
+See [developing River UI](./docs/development.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,8 +1,6 @@
-# River UI
+# River UI development
 
 River UI consists of two apps: a Go backend API, and a TypeScript UI frontend.
-
-## Local development
 
 ### Migrate database
 


### PR DESCRIPTION
Change the README to consist mainly of a description of the project
along with install instructions with binaries and container images,
which will be more useful to most people looking at the project.

In sitting with the same convention as River, move development
instructions to `./docs/development.md` and also move the `README.md`
into `./docs` so that we can have separate documentation for the
top-level Go package.