### PR TITLE
Add `DATABASE_URL` to Docker run command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ $ RIVER_ARCH=arm64 # either 'amd64' or 'arm64'
 $ RIVER_OS=darwin  # either 'darwin' or 'linux'
 $ curl -L https://github.com/riverqueue/riverui/releases/latest/download/riverui_${RIVER_OS}_${RIVER_ARCH}.gz | gzip -d > riverui
 $ chmod +x riverui
+$ export DATABASE_URL=...
 $ ./riverui
 ```
 
@@ -36,7 +37,7 @@ River UI ships [container images](https://github.com/riverqueue/riverui/pkgs/con
 
 ```sh
 $ docker pull ghcr.io/riverqueue/riverui:latest
-$ docker run ghcr.io/riverqueue/riverui:latest
+$ docker run ghcr.io/riverqueue/riverui:latest --env DATABASE_URL
 ```
 
 ## Development


### PR DESCRIPTION
A very minor amendment in the README container instructions to add
`--env DATABASE_URL` to the Docker run command to show that one should
forward a database URL into the container for it to work properly.

I also added it to the binary run instructions for similar reasons.