### PR TITLE
Add changelog and prepare 0.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2024-06-20
+
+### Added
+
+- This is the initial release of River UI.


### PR DESCRIPTION
Add a changelog and prepare for a 0.0.1 release. We follow all the same
conventions as the main River project.