### PR TITLE
fix job list pagination flashing w/ placeholderData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix job list pagination flashing using TanStack Query's `placeholderData` feature. [PR #56](https://github.com/riverqueue/riverui/pull/56).
+
 ## [0.0.1] - 2024-06-20
 
 ### Added

--- a/ui/src/services/jobs.ts
+++ b/ui/src/services/jobs.ts
@@ -115,23 +115,23 @@ export const deleteJobs: MutationFunction<void, DeletePayload> = async ({
 };
 
 type ListJobsFilters = {
-  limit?: number;
-  state?: JobState;
+  limit: number;
+  state: JobState;
 };
 
-type ListJobsKey = ["listJobs", ListJobsFilters];
+export type ListJobsKey = ["listJobs", JobState, number];
 
 export const listJobsKey = (args: ListJobsFilters): ListJobsKey => {
-  return ["listJobs", args];
+  return ["listJobs", args.state, args.limit];
 };
 
 export const listJobs: QueryFunction<Job[], ListJobsKey> = async ({
   queryKey,
   signal,
 }) => {
-  const [, searchParams] = queryKey;
+  const [, state, limit] = queryKey;
   const searchParamsStringValues = Object.fromEntries(
-    Object.entries(searchParams).map(([k, v]) => [k, String(v)])
+    Object.entries({ state, limit }).map(([k, v]) => [k, String(v)])
   );
   const query = new URLSearchParams(searchParamsStringValues);
 


### PR DESCRIPTION
Use the approaches outlined on the paginated queries and placeholder data docs for Tanstack Query to ensure that the page doesn't flash disruptively when changing the pagination count, so long as the rest of the params are still unchanged (`state`).

https://tanstack.com/query/latest/docs/framework/react/guides/paginated-queries#better-paginated-queries-with-placeholderdata https://tanstack.com/query/latest/docs/framework/react/guides/placeholder-query-data

Fixes #55.