### PR TITLE
multi-selectable job rows w/ shift select, actions bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Make job list items selectable so they can be cancelled, retried, or deleted as a batch. [PR #57](https://github.com/riverqueue/riverui/pull/57).
+
 ### Fixed
 
 - Fix job list pagination flashing using TanStack Query's `placeholderData` feature. [PR #56](https://github.com/riverqueue/riverui/pull/56).

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -11,6 +11,9 @@ const styles = {
     // Base
     "relative isolate inline-flex items-center justify-center gap-x-2 rounded-lg border text-base/6 font-semibold",
 
+    // Pointer
+    "disabled:cursor-not-allowed data-[disabled]:cursor-not-allowed enabled:cursor-pointer",
+
     // Sizing
     "px-[calc(theme(spacing[3.5])-1px)] py-[calc(theme(spacing[2.5])-1px)] sm:px-[calc(theme(spacing.3)-1px)] sm:py-[calc(theme(spacing[1.5])-1px)] sm:text-sm/6",
 

--- a/ui/src/components/ButtonForGroup.tsx
+++ b/ui/src/components/ButtonForGroup.tsx
@@ -1,0 +1,29 @@
+import { Heroicon } from "@services/types";
+import { FormEvent } from "react";
+import { Button, ButtonProps } from "./Button";
+import { classNames } from "@utils/style";
+
+export default function ButtonForGroup({
+  className,
+  Icon,
+  text,
+  ...props
+}: {
+  Icon: Heroicon;
+  onClick?: (event: FormEvent) => void;
+  text: string;
+} & Omit<ButtonProps, "children" | "color" | "outline" | "plain">) {
+  return (
+    <Button
+      outline
+      className={classNames(
+        "rounded-none first:rounded-l-md last:rounded-r-md",
+        className || ""
+      )}
+      {...props}
+    >
+      <Icon className="mr-2 size-5" aria-hidden="true" />
+      {text}
+    </Button>
+  );
+}

--- a/ui/src/components/Checkbox.tsx
+++ b/ui/src/components/Checkbox.tsx
@@ -1,0 +1,164 @@
+import * as Headless from "@headlessui/react";
+import { clsx } from "clsx";
+import type React from "react";
+
+// This comes from Catalyst, but it (and Headless UI) do not allow us to capture
+// whether the shift key is held while toggled, which means we can't use it for
+// shift multi select.
+
+export function CheckboxGroup({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      data-slot="control"
+      {...props}
+      className={clsx(
+        className,
+        // Basic groups
+        "space-y-3",
+        // With descriptions
+        "has-[[data-slot=description]]:space-y-6 [&_[data-slot=label]]:has-[[data-slot=description]]:font-medium"
+      )}
+    />
+  );
+}
+
+export function CheckboxField({
+  className,
+  ...props
+}: { className?: string } & Omit<Headless.FieldProps, "className">) {
+  return (
+    <Headless.Field
+      data-slot="field"
+      {...props}
+      className={clsx(
+        className,
+        // Base layout
+        "grid grid-cols-[1.125rem_1fr] items-center gap-x-4 gap-y-1 sm:grid-cols-[1rem_1fr]",
+        // Control layout
+        "[&>[data-slot=control]]:col-start-1 [&>[data-slot=control]]:row-start-1 [&>[data-slot=control]]:justify-self-center",
+        // Label layout
+        "[&>[data-slot=label]]:col-start-2 [&>[data-slot=label]]:row-start-1 [&>[data-slot=label]]:justify-self-start",
+        // Description layout
+        "[&>[data-slot=description]]:col-start-2 [&>[data-slot=description]]:row-start-2",
+        // With description
+        "[&_[data-slot=label]]:has-[[data-slot=description]]:font-medium"
+      )}
+    />
+  );
+}
+
+const base = [
+  // Basic layout
+  "relative isolate flex size-[1.125rem] items-center justify-center rounded-[0.3125rem] sm:size-4",
+  // Background color + shadow applied to inset pseudo element, so shadow blends with border in light mode
+  "before:absolute before:inset-0 before:-z-10 before:rounded-[calc(0.3125rem-1px)] before:bg-white before:shadow",
+  // Background color when checked
+  "before:group-data-[checked]:bg-[--checkbox-checked-bg]",
+  // Background color is moved to control and shadow is removed in dark mode so hide `before` pseudo
+  "dark:before:hidden",
+  // Background color applied to control in dark mode
+  "dark:bg-white/5 dark:group-data-[checked]:bg-[--checkbox-checked-bg]",
+  // Border
+  "border border-zinc-950/15 group-data-[checked]:border-transparent group-data-[checked]:group-data-[hover]:border-transparent group-data-[hover]:border-zinc-950/30 group-data-[checked]:bg-[--checkbox-checked-border]",
+  "dark:border-white/15 dark:group-data-[checked]:border-white/5 dark:group-data-[checked]:group-data-[hover]:border-white/5 dark:group-data-[hover]:border-white/30",
+  // Inner highlight shadow
+  "after:absolute after:inset-0 after:rounded-[calc(0.3125rem-1px)] after:shadow-[inset_0_1px_theme(colors.white/15%)]",
+  "dark:after:-inset-px dark:after:hidden dark:after:rounded-[0.3125rem] dark:group-data-[checked]:after:block",
+  // Focus ring
+  "group-data-[focus]:outline group-data-[focus]:outline-2 group-data-[focus]:outline-offset-2 group-data-[focus]:outline-blue-500",
+  // Disabled state
+  "group-data-[disabled]:opacity-50",
+  "group-data-[disabled]:border-zinc-950/25 group-data-[disabled]:bg-zinc-950/5 group-data-[disabled]:[--checkbox-check:theme(colors.zinc.950/50%)] group-data-[disabled]:before:bg-transparent",
+  "dark:group-data-[disabled]:border-white/20 dark:group-data-[disabled]:bg-white/[2.5%] dark:group-data-[disabled]:[--checkbox-check:theme(colors.white/50%)] dark:group-data-[disabled]:group-data-[checked]:after:hidden",
+  // Forced colors mode
+  "forced-colors:[--checkbox-check:HighlightText] forced-colors:[--checkbox-checked-bg:Highlight] forced-colors:group-data-[disabled]:[--checkbox-check:Highlight]",
+  "dark:forced-colors:[--checkbox-check:HighlightText] dark:forced-colors:[--checkbox-checked-bg:Highlight] dark:forced-colors:group-data-[disabled]:[--checkbox-check:Highlight]",
+];
+
+const colors = {
+  "dark/zinc": [
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.zinc.900)] [--checkbox-checked-border:theme(colors.zinc.950/90%)]",
+    "dark:[--checkbox-checked-bg:theme(colors.zinc.600)]",
+  ],
+  "dark/white": [
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.zinc.900)] [--checkbox-checked-border:theme(colors.zinc.950/90%)]",
+    "dark:[--checkbox-check:theme(colors.zinc.900)] dark:[--checkbox-checked-bg:theme(colors.white)] dark:[--checkbox-checked-border:theme(colors.zinc.950/15%)]",
+  ],
+  white:
+    "[--checkbox-check:theme(colors.zinc.900)] [--checkbox-checked-bg:theme(colors.white)] [--checkbox-checked-border:theme(colors.zinc.950/15%)]",
+  dark: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.zinc.900)] [--checkbox-checked-border:theme(colors.zinc.950/90%)]",
+  zinc: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.zinc.600)] [--checkbox-checked-border:theme(colors.zinc.700/90%)]",
+  red: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.red.600)] [--checkbox-checked-border:theme(colors.red.700/90%)]",
+  orange:
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.orange.500)] [--checkbox-checked-border:theme(colors.orange.600/90%)]",
+  amber:
+    "[--checkbox-check:theme(colors.amber.950)] [--checkbox-checked-bg:theme(colors.amber.400)] [--checkbox-checked-border:theme(colors.amber.500/80%)]",
+  yellow:
+    "[--checkbox-check:theme(colors.yellow.950)] [--checkbox-checked-bg:theme(colors.yellow.300)] [--checkbox-checked-border:theme(colors.yellow.400/80%)]",
+  lime: "[--checkbox-check:theme(colors.lime.950)] [--checkbox-checked-bg:theme(colors.lime.300)] [--checkbox-checked-border:theme(colors.lime.400/80%)]",
+  green:
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.green.600)] [--checkbox-checked-border:theme(colors.green.700/90%)]",
+  emerald:
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.emerald.600)] [--checkbox-checked-border:theme(colors.emerald.700/90%)]",
+  teal: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.teal.600)] [--checkbox-checked-border:theme(colors.teal.700/90%)]",
+  cyan: "[--checkbox-check:theme(colors.cyan.950)] [--checkbox-checked-bg:theme(colors.cyan.300)] [--checkbox-checked-border:theme(colors.cyan.400/80%)]",
+  sky: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.sky.500)] [--checkbox-checked-border:theme(colors.sky.600/80%)]",
+  blue: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.blue.600)] [--checkbox-checked-border:theme(colors.blue.700/90%)]",
+  indigo:
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.indigo.500)] [--checkbox-checked-border:theme(colors.indigo.600/90%)]",
+  violet:
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.violet.500)] [--checkbox-checked-border:theme(colors.violet.600/90%)]",
+  purple:
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.purple.500)] [--checkbox-checked-border:theme(colors.purple.600/90%)]",
+  fuchsia:
+    "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.fuchsia.500)] [--checkbox-checked-border:theme(colors.fuchsia.600/90%)]",
+  pink: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.pink.500)] [--checkbox-checked-border:theme(colors.pink.600/90%)]",
+  rose: "[--checkbox-check:theme(colors.white)] [--checkbox-checked-bg:theme(colors.rose.500)] [--checkbox-checked-border:theme(colors.rose.600/90%)]",
+};
+
+type Color = keyof typeof colors;
+
+export function Checkbox({
+  color = "dark/zinc",
+  className,
+  ...props
+}: {
+  color?: Color;
+  className?: string;
+} & Omit<Headless.CheckboxProps, "className">) {
+  return (
+    <Headless.Checkbox
+      data-slot="control"
+      {...props}
+      className={clsx(className, "group inline-flex focus:outline-none")}
+    >
+      <span className={clsx([base, colors[color]])}>
+        <svg
+          className="size-4 stroke-[--checkbox-check] opacity-0 group-data-[checked]:opacity-100 sm:size-3.5"
+          viewBox="0 0 14 14"
+          fill="none"
+        >
+          {/* Checkmark icon */}
+          <path
+            className="opacity-100 group-data-[indeterminate]:opacity-0"
+            d="M3 8L6 11L11 3.5"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          {/* Indeterminate icon */}
+          <path
+            className="opacity-0 group-data-[indeterminate]:opacity-100"
+            d="M3 7H11"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    </Headless.Checkbox>
+  );
+}

--- a/ui/src/components/CustomCheckbox.tsx
+++ b/ui/src/components/CustomCheckbox.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { classNames } from "@utils/style";
+
+export function CustomCheckbox({
+  checked,
+  className,
+  onChange,
+  indeterminate,
+  ...props
+}: {
+  className?: string;
+  indeterminate?: boolean;
+  onChange?: (
+    checked: boolean,
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => void;
+} & Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "className" | "onChange" | "type"
+>) {
+  const checkboxRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (checkboxRef.current) {
+      checkboxRef.current.indeterminate = Boolean(indeterminate);
+    }
+  }, [indeterminate]);
+
+  const controlledOnChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (onChange) {
+        onChange(!checked, event);
+      }
+    },
+    [checked, onChange]
+  );
+
+  return (
+    <input
+      ref={checkboxRef}
+      checked={checked}
+      className={classNames(
+        "h-4 w-4 rounded border-slate-300 text-brand-primary focus:ring-indigo-600",
+        // Background color applied to control in dark mode
+        "dark:bg-white/5 dark:border-slate-700",
+        className || ""
+      )}
+      onChange={controlledOnChange}
+      type="checkbox"
+      {...props}
+    />
+  );
+}

--- a/ui/src/components/JobDetail.tsx
+++ b/ui/src/components/JobDetail.tsx
@@ -5,7 +5,7 @@ import {
 } from "@heroicons/react/24/outline";
 
 import { Job } from "@services/jobs";
-import { Heroicon, JobState } from "@services/types";
+import { JobState } from "@services/types";
 import { capitalize } from "@utils/string";
 import JobTimeline from "./JobTimeline";
 import { FormEvent, useMemo, useState } from "react";
@@ -13,7 +13,7 @@ import TopNavTitleOnly from "./TopNavTitleOnly";
 import RelativeTimeFormatter from "./RelativeTimeFormatter";
 import JobAttemptErrors from "./JobAttemptErrors";
 import { Badge } from "./Badge";
-import { Button, ButtonProps } from "./Button";
+import ButtonForGroup from "./ButtonForGroup";
 
 type JobDetailProps = {
   cancel: () => void;
@@ -21,27 +21,6 @@ type JobDetailProps = {
   job: Job;
   retry: () => void;
 };
-
-function ButtonForGroup({
-  Icon,
-  text,
-  ...props
-}: {
-  Icon: Heroicon;
-  onClick?: (event: FormEvent) => void;
-  text: string;
-} & Omit<ButtonProps, "children" | "color" | "outline" | "plain">) {
-  return (
-    <Button
-      outline
-      {...props}
-      className="rounded-none first:rounded-l-md last:rounded-r-md"
-    >
-      <Icon className="mr-2 size-5" aria-hidden="true" />
-      {text}
-    </Button>
-  );
-}
 
 function ActionButtons({
   cancel,

--- a/ui/src/hooks/use-selected.ts
+++ b/ui/src/hooks/use-selected.ts
@@ -1,0 +1,44 @@
+import { useCallback, useState } from "react";
+
+export const useSelected = <P>(initialState: Array<P>) => {
+  const [selected, setSelected] = useState<Set<P>>(new Set(initialState));
+
+  const add = useCallback((items: Array<P>) => {
+    setSelected((oldSet) => {
+      const newSet = new Set(oldSet);
+      items.forEach((item) => newSet.add(item));
+      return newSet;
+    });
+  }, []);
+
+  const remove = useCallback((items: Array<P>) => {
+    setSelected((oldSet) => {
+      const newSet = new Set(oldSet);
+      items.forEach((item) => newSet.delete(item));
+      return newSet;
+    });
+  }, []);
+
+  const change = useCallback(
+    (addOrRemove: boolean, items: Array<P>) => {
+      if (addOrRemove) {
+        add(items);
+      } else {
+        remove(items);
+      }
+    },
+    [add, remove]
+  );
+
+  const clear = useCallback(() => setSelected(new Set()), []);
+
+  // Convert the Set to an array when returning
+  return {
+    selected: Array.from(selected),
+    selectedSet: selected,
+    add,
+    remove,
+    clear,
+    change,
+  };
+};

--- a/ui/src/hooks/use-shift-selected.ts
+++ b/ui/src/hooks/use-shift-selected.ts
@@ -1,0 +1,70 @@
+import { ChangeEvent, useCallback, useState } from "react";
+
+/**
+ * Note: Shift + Space doesn't work. You need to use something like this,
+ *
+ * ```
+ * onKeyUp={(event) => {
+ *   if (event.code === 'Space' && event.target.disabled) {
+ *     onChange(event as any, member)
+ *   }
+ * }}
+ * ```
+ */
+export const useShiftSelected = <P>(
+  initialState: Array<P>,
+  change: (addOrRemove: boolean, items: Array<P>) => void
+) => {
+  const [previousSelected, setPreviousSelected] = useState<P | null>(null);
+  const [previousChecked, setPreviousChecked] = useState<boolean>(false);
+  const [currentSelected, setCurrentSelected] = useState<P | null>(null);
+
+  const onChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>, item: P) => {
+      // @ts-expect-error shiftKey is defined for click events
+      if (event.nativeEvent.shiftKey) {
+        const current = initialState.findIndex((x) => x === item);
+        const previous = initialState.findIndex((x) => x === previousSelected);
+        const previousCurrent = initialState.findIndex(
+          (x) => x === currentSelected
+        );
+        const start = Math.min(current, previous);
+        const end = Math.max(current, previous);
+        if (start > -1 && end > -1) {
+          change(previousChecked, initialState.slice(start, end + 1));
+          if (previousCurrent > end) {
+            change(
+              !previousChecked,
+              initialState.slice(end + 1, previousCurrent + 1)
+            );
+          }
+          if (previousCurrent < start) {
+            change(
+              !previousChecked,
+              initialState.slice(previousCurrent, start)
+            );
+          }
+          setCurrentSelected(item);
+          return;
+        }
+      } else {
+        setPreviousSelected(item);
+        setCurrentSelected(null);
+        setPreviousChecked(event.target.checked);
+      }
+      change(event.target.checked, [item]);
+    },
+    [
+      change,
+      initialState,
+      previousSelected,
+      setPreviousSelected,
+      previousChecked,
+      setPreviousChecked,
+      currentSelected,
+      setCurrentSelected,
+    ]
+  );
+
+  return onChange;
+};


### PR DESCRIPTION
This adds checkboxes to each row on the job list, as well as a select/deselect all box on a new header row above the list. Checking any jobs causes the job list to stop refreshing until everything is unchecked.

Depending on the state being viewed, selected jobs can be retried, cancelled, or deleted as a batch. Performing any action on selected jobs causes the TanStack query cache to be invalidated for the job list and the counts by state so those get immediately refetched.

Selection even works with the shift key to select all jobs between the previous one you checked and the one you just checked.

![localhost_5173_jobs_state=running](https://github.com/riverqueue/riverui/assets/114033/c37e6e53-ca77-4e34-aa4e-a88adcb79d92)
![localhost_5173_jobs_state=running (1)](https://github.com/riverqueue/riverui/assets/114033/2947017f-fd57-411f-a2e9-b157edc7af23)
![localhost_5173_jobs_state=running (2)](https://github.com/riverqueue/riverui/assets/114033/3e4ac78c-d214-4292-94f2-d25fa93e0238)

Fixes #54.