### PR TITLE
Match sqlc options of main River project

### DIFF
--- a/api_handler_test.go
+++ b/api_handler_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 	"github.com/riverqueue/riverui/internal/apierror"
-	"github.com/riverqueue/riverui/internal/db"
 	"github.com/riverqueue/riverui/internal/riverinternaltest"
 )
 
@@ -31,10 +30,9 @@ func setupEndpoint[TEndpoint any](ctx context.Context, t *testing.T) (*TEndpoint
 
 	if withSetBundle, ok := any(&endpoint).(withSetBundle); ok {
 		withSetBundle.SetBundle(&apiBundle{
-			client:  client,
-			dbPool:  tx,
-			logger:  logger,
-			queries: db.New(tx),
+			client: client,
+			dbPool: tx,
+			logger: logger,
 		})
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -78,10 +78,9 @@ func NewHandler(opts *HandlerOpts) (http.Handler, error) {
 	serveIndex := serveFileContents("index.html", httpFS)
 
 	apiBundle := apiBundle{
-		client:  opts.Client,
-		dbPool:  opts.DBPool,
-		logger:  opts.Logger,
-		queries: db.New(opts.DBPool),
+		client: opts.Client,
+		dbPool: opts.DBPool,
+		logger: opts.Logger,
 	}
 
 	handler := &apiHandler{apiBundle: apiBundle}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -17,16 +17,9 @@ type DBTX interface {
 	QueryRow(context.Context, string, ...interface{}) pgx.Row
 }
 
-func New(db DBTX) *Queries {
-	return &Queries{db: db}
+func New() *Queries {
+	return &Queries{}
 }
 
 type Queries struct {
-	db DBTX
-}
-
-func (q *Queries) WithTx(tx pgx.Tx) *Queries {
-	return &Queries{
-		db: tx,
-	}
 }

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -56,19 +56,19 @@ type JobCountByQueueAndStateRow struct {
 	RunningJobsCount   int64
 }
 
-func (q *Queries) JobCountByQueueAndState(ctx context.Context, queueNames []string) ([]JobCountByQueueAndStateRow, error) {
-	rows, err := q.db.Query(ctx, jobCountByQueueAndState, queueNames)
+func (q *Queries) JobCountByQueueAndState(ctx context.Context, db DBTX, queueNames []string) ([]*JobCountByQueueAndStateRow, error) {
+	rows, err := db.Query(ctx, jobCountByQueueAndState, queueNames)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []JobCountByQueueAndStateRow
+	var items []*JobCountByQueueAndStateRow
 	for rows.Next() {
 		var i JobCountByQueueAndStateRow
 		if err := rows.Scan(&i.Queue, &i.AvailableJobsCount, &i.RunningJobsCount); err != nil {
 			return nil, err
 		}
-		items = append(items, i)
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -95,19 +95,19 @@ type JobCountByStateRow struct {
 	Count int64
 }
 
-func (q *Queries) JobCountByState(ctx context.Context) ([]JobCountByStateRow, error) {
-	rows, err := q.db.Query(ctx, jobCountByState)
+func (q *Queries) JobCountByState(ctx context.Context, db DBTX) ([]*JobCountByStateRow, error) {
+	rows, err := db.Query(ctx, jobCountByState)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []JobCountByStateRow
+	var items []*JobCountByStateRow
 	for rows.Next() {
 		var i JobCountByStateRow
 		if err := rows.Scan(&i.State, &i.Count); err != nil {
 			return nil, err
 		}
-		items = append(items, i)
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -134,13 +134,13 @@ type JobListWorkflowParams struct {
 	PaginationLimit  int32
 }
 
-func (q *Queries) JobListWorkflow(ctx context.Context, arg JobListWorkflowParams) ([]RiverJob, error) {
-	rows, err := q.db.Query(ctx, jobListWorkflow, arg.WorkflowID, arg.PaginationOffset, arg.PaginationLimit)
+func (q *Queries) JobListWorkflow(ctx context.Context, db DBTX, arg *JobListWorkflowParams) ([]*RiverJob, error) {
+	rows, err := db.Query(ctx, jobListWorkflow, arg.WorkflowID, arg.PaginationOffset, arg.PaginationLimit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []RiverJob
+	var items []*RiverJob
 	for rows.Next() {
 		var i RiverJob
 		if err := rows.Scan(
@@ -163,7 +163,7 @@ func (q *Queries) JobListWorkflow(ctx context.Context, arg JobListWorkflowParams
 		); err != nil {
 			return nil, err
 		}
-		items = append(items, i)
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/db/sqlc.yaml
+++ b/internal/db/sqlc.yaml
@@ -8,3 +8,7 @@ sql:
         package: "db"
         sql_package: "pgx/v5"
         out: "."
+        emit_exact_table_names: true
+        emit_methods_with_db_argument: true
+        emit_params_struct_pointers: true
+        emit_result_struct_pointers: true


### PR DESCRIPTION
I'm finding it a little disorienting that the use of sqlc functions in
River UI are a little different than their use in the main River project
due to the options in play being a little different. e.g. DBTX as a
`New()` argument instead of one to the function itself, non-pointer
parameters and return values.

Here, match the sqlc options with the main River project, and update
call sites so everything works.