### PR TITLE
Add more elaborate health check endpoint that optionally hits the database

### DIFF
--- a/api_handler.go
+++ b/api_handler.go
@@ -275,6 +275,10 @@ func (a *apiHandler) JobList(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (a *apiHandler) Healthcheck(rw http.ResponseWriter, req *http.Request) {
+	a.writeResponse(req.Context(), rw, []byte("{\"status\": \"ok\"}"))
+}
+
 func (a *apiHandler) QueueGet(rw http.ResponseWriter, req *http.Request) {
 	ctx, cancel := context.WithTimeout(req.Context(), 5*time.Second)
 	defer cancel()

--- a/api_handler.go
+++ b/api_handler.go
@@ -42,9 +42,63 @@ type withSetBundle interface {
 	SetBundle(bundle *apiBundle)
 }
 
+type statusResponse struct {
+	Status string `json:"status"`
+}
+
+var statusResponseOK = &statusResponse{Status: "ok"} //nolint:gochecknoglobals
+
+type healthCheckGetEndpoint struct {
+	apiBundle
+	apiendpoint.Endpoint[healthCheckGetRequest, statusResponse]
+}
+
+func (*healthCheckGetEndpoint) Meta() *apiendpoint.EndpointMeta {
+	return &apiendpoint.EndpointMeta{
+		Pattern:    "GET /api/health-checks/{name}",
+		StatusCode: http.StatusOK,
+	}
+}
+
+type healthCheckName string
+
+const (
+	healthCheckNameComplete healthCheckName = "complete"
+	healthCheckNameMinimal  healthCheckName = "minimal"
+)
+
+type healthCheckGetRequest struct {
+	Name healthCheckName `json:"-"` // from ExtractRaw
+}
+
+func (req *healthCheckGetRequest) ExtractRaw(r *http.Request) error {
+	req.Name = healthCheckName(r.PathValue("name"))
+	return nil
+}
+
+func (a *healthCheckGetEndpoint) Execute(ctx context.Context, req *healthCheckGetRequest) (*statusResponse, error) {
+	switch req.Name {
+	case healthCheckNameComplete:
+		if _, err := a.dbPool.Exec(ctx, "SELECT 1"); err != nil {
+			return nil, apierror.WithInternalError(
+				apierror.NewServiceUnavailable("Unable to query database. Check logs for details."),
+				err,
+			)
+		}
+
+	case healthCheckNameMinimal:
+		// fall through to OK status response below
+
+	default:
+		return nil, apierror.NewNotFound("Health check %q not found. Use either `complete` or `minimal`.", req.Name)
+	}
+
+	return statusResponseOK, nil
+}
+
 type jobCancelEndpoint struct {
 	apiBundle
-	apiendpoint.Endpoint[jobCancelRequest, jobCancelResponse]
+	apiendpoint.Endpoint[jobCancelRequest, statusResponse]
 }
 
 func (*jobCancelEndpoint) Meta() *apiendpoint.EndpointMeta {
@@ -58,12 +112,8 @@ type jobCancelRequest struct {
 	JobIDs []int64String `json:"ids"`
 }
 
-type jobCancelResponse struct {
-	Status string `json:"status"`
-}
-
-func (a *jobCancelEndpoint) Execute(ctx context.Context, req *jobCancelRequest) (*jobCancelResponse, error) {
-	return dbutil.WithTxV(ctx, a.dbPool, func(ctx context.Context, tx pgx.Tx) (*jobCancelResponse, error) {
+func (a *jobCancelEndpoint) Execute(ctx context.Context, req *jobCancelRequest) (*statusResponse, error) {
+	return dbutil.WithTxV(ctx, a.dbPool, func(ctx context.Context, tx pgx.Tx) (*statusResponse, error) {
 		updatedJobs := make(map[int64]*rivertype.JobRow)
 		for _, jobID := range req.JobIDs {
 			jobID := int64(jobID)
@@ -78,7 +128,7 @@ func (a *jobCancelEndpoint) Execute(ctx context.Context, req *jobCancelRequest) 
 		}
 
 		// TODO: return jobs in response, use in frontend instead of invalidating
-		return &jobCancelResponse{Status: "ok"}, nil
+		return statusResponseOK, nil
 	})
 }
 
@@ -273,10 +323,6 @@ func (a *apiHandler) JobList(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-}
-
-func (a *apiHandler) Healthcheck(rw http.ResponseWriter, req *http.Request) {
-	a.writeResponse(req.Context(), rw, []byte("{\"status\": \"ok\"}"))
 }
 
 func (a *apiHandler) QueueGet(rw http.ResponseWriter, req *http.Request) {

--- a/handler.go
+++ b/handler.go
@@ -100,6 +100,7 @@ func NewHandler(opts *HandlerOpts) (http.Handler, error) {
 	mux.HandleFunc("GET /api/workflows/{id}", handler.WorkflowGet)
 	mux.HandleFunc("GET /api/states", handler.StatesAndCounts)
 	mux.HandleFunc("/api", http.NotFound)
+	mux.HandleFunc("GET /healthcheck", handler.Healthcheck)
 	mux.Handle("/", intercept404(fileServer, serveIndex))
 
 	if prefix != "/" {

--- a/handler.go
+++ b/handler.go
@@ -88,6 +88,7 @@ func NewHandler(opts *HandlerOpts) (http.Handler, error) {
 	prefix := opts.Prefix
 
 	mux := http.NewServeMux()
+	apiendpoint.Mount(mux, opts.Logger, &healthCheckGetEndpoint{apiBundle: apiBundle})
 	mux.HandleFunc("GET /api/jobs", handler.JobList)
 	apiendpoint.Mount(mux, opts.Logger, &jobCancelEndpoint{apiBundle: apiBundle})
 	mux.HandleFunc("POST /api/jobs/delete", handler.JobDelete)
@@ -100,7 +101,6 @@ func NewHandler(opts *HandlerOpts) (http.Handler, error) {
 	mux.HandleFunc("GET /api/workflows/{id}", handler.WorkflowGet)
 	mux.HandleFunc("GET /api/states", handler.StatesAndCounts)
 	mux.HandleFunc("/api", http.NotFound)
-	mux.HandleFunc("GET /healthcheck", handler.Healthcheck)
 	mux.Handle("/", intercept404(fileServer, serveIndex))
 
 	if prefix != "/" {

--- a/handler_test.go
+++ b/handler_test.go
@@ -88,6 +88,8 @@ func TestNewHandlerIntegration(t *testing.T) {
 	// API calls
 	//
 
+	makeAPICall(t, "HealthCheckGetComplete", http.MethodGet, makeURL("/api/health-checks/%s", healthCheckNameComplete), nil)
+	makeAPICall(t, "HealthCheckGetMinimal", http.MethodGet, makeURL("/api/health-checks/%s", healthCheckNameMinimal), nil)
 	makeAPICall(t, "JobCancel", http.MethodPost, makeURL("/api/jobs/cancel"), mustMarshalJSON(t, &jobCancelRequest{JobIDs: []int64String{int64String(job.ID)}}))
 	makeAPICall(t, "JobGet", http.MethodGet, makeURL("/api/jobs/%d", job.ID), nil)
 }

--- a/internal/apiendpoint/api_endpoint.go
+++ b/internal/apiendpoint/api_endpoint.go
@@ -141,8 +141,17 @@ func executeAPIEndpoint[TReq any, TResp any](w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		var apiErr apierror.Interface
 		if errors.As(err, &apiErr) {
+			logAttrs := []any{
+				slog.String("error", apiErr.Error()),
+			}
+
+			if internalErr := apiErr.GetInternalError(); internalErr != nil {
+				logAttrs = append(logAttrs, slog.String("internal_error", internalErr.Error()))
+			}
+
 			// Logged at info level because API errors are normal.
-			logger.InfoContext(ctx, "API error response", slog.String("error", apiErr.Error()))
+			logger.InfoContext(ctx, "API error response", logAttrs...)
+
 			apiErr.Write(ctx, logger, w)
 			return
 		}

--- a/internal/apierror/api_error_test.go
+++ b/internal/apierror/api_error_test.go
@@ -3,6 +3,7 @@ package apierror
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -10,6 +11,18 @@ import (
 
 	"github.com/riverqueue/riverui/internal/riverinternaltest"
 )
+
+func TestAPIError(t *testing.T) {
+	t.Parallel()
+
+	var (
+		anErr  = errors.New("an error")
+		apiErr = NewBadRequest("Bad request.")
+	)
+
+	apiErr.SetInternalError(anErr)
+	require.Equal(t, anErr, apiErr.GetInternalError())
+}
 
 func TestAPIErrorJSON(t *testing.T) {
 	t.Parallel()
@@ -38,6 +51,18 @@ func TestAPIErrorWrite(t *testing.T) {
 		`{"message":"Bad request. Try sending JSON next time."}`,
 		recorder.Body.String(),
 	)
+}
+
+func TestWithInternalError(t *testing.T) {
+	t.Parallel()
+
+	var (
+		anErr  = errors.New("an error")
+		apiErr = NewBadRequest("Bad request.")
+	)
+
+	apiErr = WithInternalError(apiErr, anErr)
+	require.Equal(t, anErr, apiErr.InternalError)
 }
 
 func mustMarshalJSON(t *testing.T, v any) []byte {


### PR DESCRIPTION
An alternative to #68 that adds a pair of health check endpoints:

* `GET /api/health-checks/complete`
* `GET /api/health-checks/minimal`

The minimal endpoint just returns an OK response regardless of anything 
else so it'll return 200 as long as the Go process is up. The complete 
endpoint runs the additional check of pinging the database, verifying its
liveliness as well. This is useful because if the database is totally down
then River UI will be totally non-functional, but the minimal endpoint
would still return OK, and it's nice to have an alternative that'll return
an unhealthy status. Based on something I wrote about last year here [1].

Fixes #67.

[1] https://brandur.org/fragments/database-health-check