### PR TITLE
Add changelog entry for health check endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add health check endpoints. [PR #61](https://github.com/riverqueue/riverui/pull/61).
+    - `GET /api/health-checks/complete` (Returns okay if the Go process is running and the database is healthy.)
+    - `GET /api/health-checks/minimal` (Returns okay as long as Go process is running.)
+
 ## [0.1.1] - 2024-06-23
 
 ### Fixed


### PR DESCRIPTION
Oops, I forgot to add a changelog entry for #72, but given it's a
feature somewhat meant to be used by users, it should probably get one.