### PR TITLE
Convert remaining API endpoints + tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/go-playground/validator/v10 v10.22.0
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/joho/godotenv v1.5.1
@@ -21,7 +22,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect

--- a/handler.go
+++ b/handler.go
@@ -83,22 +83,21 @@ func NewHandler(opts *HandlerOpts) (http.Handler, error) {
 		logger: opts.Logger,
 	}
 
-	handler := &apiHandler{apiBundle: apiBundle}
 	prefix := opts.Prefix
 
 	mux := http.NewServeMux()
 	apiendpoint.Mount(mux, opts.Logger, &healthCheckGetEndpoint{apiBundle: apiBundle})
-	mux.HandleFunc("GET /api/jobs", handler.JobList)
 	apiendpoint.Mount(mux, opts.Logger, &jobCancelEndpoint{apiBundle: apiBundle})
-	mux.HandleFunc("POST /api/jobs/delete", handler.JobDelete)
-	mux.HandleFunc("POST /api/jobs/retry", handler.JobRetry)
+	apiendpoint.Mount(mux, opts.Logger, &jobDeleteEndpoint{apiBundle: apiBundle})
+	apiendpoint.Mount(mux, opts.Logger, &jobListEndpoint{apiBundle: apiBundle})
+	apiendpoint.Mount(mux, opts.Logger, &jobRetryEndpoint{apiBundle: apiBundle})
 	apiendpoint.Mount(mux, opts.Logger, &jobGetEndpoint{apiBundle: apiBundle})
 	apiendpoint.Mount(mux, opts.Logger, &queueGetEndpoint{apiBundle: apiBundle})
 	apiendpoint.Mount(mux, opts.Logger, &queueListEndpoint{apiBundle: apiBundle})
 	apiendpoint.Mount(mux, opts.Logger, &queuePauseEndpoint{apiBundle: apiBundle})
 	apiendpoint.Mount(mux, opts.Logger, &queueResumeEndpoint{apiBundle: apiBundle})
-	mux.HandleFunc("GET /api/workflows/{id}", handler.WorkflowGet)
-	mux.HandleFunc("GET /api/states", handler.StatesAndCounts)
+	apiendpoint.Mount(mux, opts.Logger, &stateAndCountGetEndpoint{apiBundle: apiBundle})
+	apiendpoint.Mount(mux, opts.Logger, &workflowGetEndpoint{apiBundle: apiBundle})
 	mux.HandleFunc("/api", http.NotFound)
 	mux.Handle("/", intercept404(fileServer, serveIndex))
 

--- a/internal/apierror/api_error.go
+++ b/internal/apierror/api_error.go
@@ -118,8 +118,9 @@ func NewNotFound(format string, a ...any) *NotFound {
 	}
 }
 
-func NewNotFoundJob(jobID int64) *NotFound   { return NewNotFound("Job not found: %d.", jobID) }
-func NewNotFoundQueue(name string) *NotFound { return NewNotFound("Queue not found: %s.", name) }
+func NewNotFoundJob(jobID int64) *NotFound    { return NewNotFound("Job not found: %d.", jobID) }
+func NewNotFoundQueue(name string) *NotFound  { return NewNotFound("Queue not found: %s.", name) }
+func NewNotFoundWorkflow(id string) *NotFound { return NewNotFound("Workflow not found: %s.", id) }
 
 //
 // ServiceUnavailable

--- a/internal/riverinternaltest/testfactory/test_factory.go
+++ b/internal/riverinternaltest/testfactory/test_factory.go
@@ -9,10 +9,72 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivertype"
 	"github.com/riverqueue/riverui/internal/util/ptrutil"
 )
+
+type JobOpts struct {
+	Attempt     *int
+	AttemptedAt *time.Time
+	CreatedAt   *time.Time
+	EncodedArgs []byte
+	Errors      [][]byte
+	FinalizedAt *time.Time
+	Kind        *string
+	MaxAttempts *int
+	Metadata    []byte
+	Priority    *int
+	Queue       *string
+	ScheduledAt *time.Time
+	State       *rivertype.JobState
+	Tags        []string
+}
+
+func Job(ctx context.Context, tb testing.TB, exec riverdriver.Executor, opts *JobOpts) *rivertype.JobRow {
+	tb.Helper()
+
+	job, err := exec.JobInsertFull(ctx, Job_Build(tb, opts))
+	require.NoError(tb, err)
+	return job
+}
+
+func Job_Build(tb testing.TB, opts *JobOpts) *riverdriver.JobInsertFullParams { //nolint:revive,stylecheck
+	tb.Helper()
+
+	encodedArgs := opts.EncodedArgs
+	if opts.EncodedArgs == nil {
+		encodedArgs = []byte("{}")
+	}
+
+	metadata := opts.Metadata
+	if opts.Metadata == nil {
+		metadata = []byte("{}")
+	}
+
+	tags := opts.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+
+	return &riverdriver.JobInsertFullParams{
+		Attempt:     ptrutil.ValOrDefault(opts.Attempt, 0),
+		AttemptedAt: opts.AttemptedAt,
+		CreatedAt:   opts.CreatedAt,
+		EncodedArgs: encodedArgs,
+		Errors:      opts.Errors,
+		FinalizedAt: opts.FinalizedAt,
+		Kind:        ptrutil.ValOrDefault(opts.Kind, "fake_job"),
+		MaxAttempts: ptrutil.ValOrDefault(opts.MaxAttempts, river.MaxAttemptsDefault),
+		Metadata:    metadata,
+		Priority:    ptrutil.ValOrDefault(opts.Priority, river.PriorityDefault),
+		Queue:       ptrutil.ValOrDefault(opts.Queue, river.QueueDefault),
+		ScheduledAt: opts.ScheduledAt,
+		State:       ptrutil.ValOrDefault(opts.State, rivertype.JobStateAvailable),
+		Tags:        tags,
+	}
+}
 
 type QueueOpts struct {
 	Metadata  []byte

--- a/ui/src/services/jobs.ts
+++ b/ui/src/services/jobs.ts
@@ -6,6 +6,7 @@ import type {
   StringEndingWithUnderscoreAt,
 } from "./types";
 import { API } from "@utils/api";
+import { ListResponse } from "./listResponse";
 
 // Represents AttemptError as received from the API. This just like AttemptError,
 // except with keys as snake_case instead of camelCase.
@@ -135,10 +136,10 @@ export const listJobs: QueryFunction<Job[], ListJobsKey> = async ({
   );
   const query = new URLSearchParams(searchParamsStringValues);
 
-  return API.get<JobFromAPI[]>({ path: "/jobs", query }, { signal }).then(
+  return API.get<ListResponse<JobFromAPI>>({ path: "/jobs", query }, { signal }).then(
     // Map from JobFromAPI to Job:
     // TODO: there must be a cleaner way to do this given the type definitions?
-    (response) => response.map(apiJobToJob)
+    (response) => response.data.map(apiJobToJob)
   );
 };
 

--- a/ui/src/services/listResponse.ts
+++ b/ui/src/services/listResponse.ts
@@ -1,0 +1,3 @@
+export type ListResponse<T> = {
+  data: T[];
+}

--- a/ui/src/services/queues.ts
+++ b/ui/src/services/queues.ts
@@ -2,6 +2,7 @@ import type { MutationFunction, QueryFunction } from "@tanstack/react-query";
 
 import type { SnakeToCamelCase, StringEndingWithUnderscoreAt } from "./types";
 import { API } from "@utils/api";
+import { ListResponse } from "./listResponse";
 
 // Represents a Queue as received from the API. This just like Queue, except with
 // string dates instead of Date objects and keys as snake_case instead of
@@ -15,10 +16,6 @@ export type QueueFromAPI = {
   paused_at?: string;
   updated_at: string;
 };
-
-type ListResponse<T> = {
-  data: T[];
-}
 
 export type Queue = {
   [Key in keyof QueueFromAPI as SnakeToCamelCase<Key>]: Key extends


### PR DESCRIPTION
Finish the other half of #77 and convert all remaining endpoints to the
new API endpoint style and add tests for them.

In TypeScript, move `ListResponse` to a new file where it can be shared
amongst jobs and queues.