### PR TITLE
Translate `oneof` validation to a user-facing error message

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -81,6 +81,10 @@ func PublicFacingMessage(validatorErr error) string {
 					message += fieldErr.Error()
 				}
 
+			case "oneof":
+				message += fmt.Sprintf(" Field `%s` should be one of the following values: %s.",
+					fieldErr.Field(), fieldErr.Param())
+
 			case "required":
 				message += fmt.Sprintf(" Field `%s` is required.", fieldErr.Field())
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -19,6 +19,7 @@ func TestFromValidator(t *testing.T) {
 		MaxInt      int      `json:"max_int"     validate:"max=0"`
 		MaxSlice    []string `json:"max_slice"   validate:"max=0"`
 		MaxString   string   `json:"max_string"  validate:"max=0"`
+		OneOf       string   `json:"one_of"      validate:"oneof=blue green"`
 		Required    string   `json:"required"    validate:"required"`
 		Unsupported string   `json:"unsupported" validate:"e164"`
 	}
@@ -31,6 +32,7 @@ func TestFromValidator(t *testing.T) {
 			MaxInt:      0,
 			MaxSlice:    []string{},
 			MaxString:   "",
+			OneOf:       "blue",
 			Required:    "value",
 			Unsupported: "+1123456789",
 		}
@@ -82,6 +84,14 @@ func TestFromValidator(t *testing.T) {
 		testStruct := validTestStruct()
 		testStruct.MinString = ""
 		require.Equal(t, "Field `min_string` must be at least 1 character(s) long.", PublicFacingMessage(validate.Struct(testStruct)))
+	})
+
+	t.Run("OneOf", func(t *testing.T) {
+		t.Parallel()
+
+		testStruct := validTestStruct()
+		testStruct.OneOf = "red"
+		require.Equal(t, "Field `one_of` should be one of the following values: blue green.", PublicFacingMessage(validate.Struct(testStruct)))
 	})
 
 	t.Run("Required", func(t *testing.T) {


### PR DESCRIPTION
A small one that I forgot to add to #78. The list endpoint uses a
`oneof` validation to verify that a valid job state is sent with the
`state` parameter. Here, make sure that a `oneof` validation is
translated to a nice user-facing error message.