### PR TITLE
Standardize on database naming `river_dev` + `river_test`

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -9,9 +9,9 @@ cp .env.example .env
 ```
 
 ```sh
-$ createdb river-development
+$ createdb river_dev
 $ go install github.com/riverqueue/river/cmd/river
-$ river migrate-up --database-url postgres://localhost/river-development
+$ river migrate-up --database-url postgres://localhost/river_dev
 ```
 
 ## Go API
@@ -29,8 +29,8 @@ The API will need a build TypeScript UI in `ui/dist`, or you'll have to serve it
 Raise test database:
 
 ```sh
-$ createdb river-test
-$ river migrate-up --database-url postgres://localhost/river-test
+$ createdb river_test
+$ river migrate-up --database-url postgres://localhost/river_test
 ```
 
 Run tests:


### PR DESCRIPTION
We have a whole bunch of ideas of what the name of the River test
database should be across like all our different projects. I'm going to
try and standardize on `river_test` everywhere, and `river_dev` for the
development database. Opened [1] over in the Ruby project.

[1] https://github.com/riverqueue/riverqueue-ruby/pull/17