### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-07-02
+
 ### Added
 
 - Add health check endpoints. [PR #61](https://github.com/riverqueue/riverui/pull/61).
     - `GET /api/health-checks/complete` (Returns okay if the Go process is running and the database is healthy.)
     - `GET /api/health-checks/minimal` (Returns okay as long as Go process is running.)
+- Interpret some types of Postgres errors to be user facing to produce better error messages in the UI. [PR #76](https://github.com/riverqueue/riverui/pull/76).
 
 ## [0.1.1] - 2024-06-23
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,3 +62,26 @@ Alternatively, build the TypeScript API to `ui/dist`, which will be included in 
 ```sh
 $ npm run build
 ```
+
+## Releasing a new version
+
+1. Fetch changes to the repo and any new tags. Export `VERSION` by incrementing the last tag:
+
+    ```shell
+    git checkout master && git pull --rebase
+    export VERSION=v0.x.y
+    git checkout -b $USER-$VERSION
+    ```
+
+2. Prepare a PR with the changes, updating `CHANGELOG.md` with any necessary additions at the same time. Have it reviewed and merged.
+
+3. Upon merge, pull down the changes, tag each module with the new version, and push the new tags:
+
+
+    ```shell
+    git pull origin master
+    git tag $VERSION
+    git push --tags
+    ```
+
+4. The build will cut a new release and create binaries automatically, but it won't have a good release message. Go the [release list](https://github.com/riverqueue/river/releases), find `$VERSION` and change the description to the release content in `CHANGELOG.md` (again, the build will have to finish first).


### PR DESCRIPTION
It's been a while since we cut a River UI release and a couple new
features and changes have some in, so I figure it's not a bad idea to
send one one. Here, prepare version 0.2.0.

Also, add some release instructions. It'd be nice if these were more
automated, but it's better to have manual release instructions instead
of nothing for now.