### PR TITLE
ensure json content type is set on json API responses

### DIFF
--- a/internal/apiendpoint/api_endpoint.go
+++ b/internal/apiendpoint/api_endpoint.go
@@ -138,6 +138,7 @@ func executeAPIEndpoint[TReq any, TResp any](w http.ResponseWriter, r *http.Requ
 			return fmt.Errorf("error marshaling response JSON: %w", err)
 		}
 
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(meta.StatusCode)
 
 		if _, err := w.Write(respData); err != nil {

--- a/internal/apiendpoint/api_endpoint_test.go
+++ b/internal/apiendpoint/api_endpoint_test.go
@@ -181,6 +181,7 @@ func requireStatusAndJSONResponse[T any](t *testing.T, expectedStatusCode int, e
 
 	require.Equal(t, expectedStatusCode, recorder.Result().StatusCode, "Unexpected status code; response body: %s", recorder.Body.String()) //nolint:bodyclose
 	require.Equal(t, expectedResp, mustUnmarshalJSON[T](t, recorder.Body.Bytes()))
+	require.Equal(t, "application/json; charset=utf-8", recorder.Header().Get("Content-Type"))
 }
 
 // Same as the above, but for a non-JSON response.

--- a/internal/apierror/api_error.go
+++ b/internal/apierror/api_error.go
@@ -38,6 +38,7 @@ func (e *APIError) SetInternalError(internalErr error) { e.InternalError = inter
 // Write writes the API error to an HTTP response, writing to the given logger
 // in case of a problem.
 func (e *APIError) Write(ctx context.Context, logger *slog.Logger, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(e.StatusCode)
 
 	respData, err := json.Marshal(e)

--- a/internal/apierror/api_error_test.go
+++ b/internal/apierror/api_error_test.go
@@ -51,6 +51,7 @@ func TestAPIErrorWrite(t *testing.T) {
 		`{"message":"Bad request. Try sending JSON next time."}`,
 		recorder.Body.String(),
 	)
+	require.Equal(t, "application/json; charset=utf-8", recorder.Header().Get("Content-Type"))
 }
 
 func TestWithInternalError(t *testing.T) {


### PR DESCRIPTION
Realized this was missing while working on something earlier. Everything is just getting text content type otherwise.