### PR TITLE
Serve `robots.txt` to prevent crawlers from accessing UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The UI now serves a `/robots.txt` that instructs crawlers to not crawl any part an installation. (You should still use an authentication layer though.) [PR #97](https://github.com/riverqueue/riverui/pull/97).
+
 ## [0.2.0] - 2024-07-02
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN go mod download
 COPY *.go internal docs/README.md LICENSE ./
 COPY cmd/ cmd/
 COPY internal/ internal/
+COPY public/ public/
 COPY ui/*.go ./ui/
 COPY --from=build-ui /app/dist ./ui/dist
 

--- a/internal/apiendpoint/api_endpoint.go
+++ b/internal/apiendpoint/api_endpoint.go
@@ -133,6 +133,10 @@ func executeAPIEndpoint[TReq any, TResp any](w http.ResponseWriter, r *http.Requ
 			return err
 		}
 
+		if rawExtractor, ok := any(resp).(RawResponder); ok {
+			return rawExtractor.RespondRaw(w)
+		}
+
 		respData, err := json.Marshal(resp)
 		if err != nil {
 			return fmt.Errorf("error marshaling response JSON: %w", err)
@@ -187,6 +191,13 @@ func executeAPIEndpoint[TReq any, TResp any](w http.ResponseWriter, r *http.Requ
 // allows them to extract information from a raw request, like path values.
 type RawExtractor interface {
 	ExtractRaw(r *http.Request) error
+}
+
+// RawResponder is an interface that can be implemented by response structs that
+// allow them to respond directly to a ResponseWriter instead of emitting the
+// normal JSON format.
+type RawResponder interface {
+	RespondRaw(w http.ResponseWriter) error
 }
 
 // Make some broad categories of internal error back into something public

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
Here, add a `robots.txt` that denies all crawler access to UI
installations. If a River UI is exposed publicly without authentication,
it's bad and a security problem, but we don't have to make it worse by
allowing crawlers to find it.

We'll add a separate `robots.txt` in the demo that will allow basic
access to top-level pages, although deny access to crawl through the
potentially tens of thousands of jobs in `/jobs/`.

There were a number of ways to go about this that were plausible. I
ended up putting in an embedded file system that can pull in static
files easily into the Go program, and which could be reused for future
static files in case they're needed. It may be a little more than we
need right now, but it wasn't much harder to do than serving a one off
static file.
