### PR TITLE
Upgrade golangci-lint from 1.56 to 1.59

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
     name: Go lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.56
+      GOLANGCI_LINT_VERSION: v1.59
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,11 @@ linters:
     - unused
 
   disable:
+    # disabled, but which we should enable after dropping support for Go 1.21 as
+    # they're kind of a good idea
+    - copyloopvar # lints to make sure that loop variables are _not_ captured since it's not required in Go 1.22+
+    - intrange # encourages for loops to range over integers like `for i := range(5)` instead of a C-style for
+
     # disabled, but which we should enable with discussion
     - wrapcheck # checks that errors are wrapped; currently not done anywhere
 
@@ -21,12 +26,12 @@ linters:
     - testpackage # requires tests in test packages like `river_test`
 
     # disabled because they're annoying/bad
+    - err113 # wants all errors to be defined as variables at the package level; quite obnoxious
     - interfacebloat # we do in fact want >10 methods on the Adapter interface or wherever we see fit.
     - godox # bans TODO statements; total non-starter at the moment
-    - goerr113 # wants all errors to be defined as variables at the package level; quite obnoxious
-    - gomnd # detects "magic numbers", which it defines as any number; annoying
     - ireturn # bans returning interfaces; questionable as is, but also buggy as hell; very, very annoying
     - lll # restricts maximum line length; annoying
+    - mnd # detects "magic numbers", which it defines as any number; annoying
     - nlreturn # requires a blank line before returns; annoying
     - wsl # a bunch of style/whitespace stuff; annoying
 


### PR DESCRIPTION
Very similar to [1], upgrade golangci-lint from 1.56 to 1.59. There's a
couple good Go 1.22 linters that were added, but I've disabled them for
now just in case we can get the River UI handler interface figured out
properly, and if we did, we'd presumably support the same versions as
the main River. Either way, we can probably enable these soon as 1.23
will be out pretty soon.

[1] https://github.com/riverqueue/river/pull/466