### PR TITLE
Fix link to riverui releases index

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -84,4 +84,4 @@ $ npm run build
     git push --tags
     ```
 
-4. The build will cut a new release and create binaries automatically, but it won't have a good release message. Go the [release list](https://github.com/riverqueue/river/releases), find `$VERSION` and change the description to the release content in `CHANGELOG.md` (again, the build will have to finish first).
+4. The build will cut a new release and create binaries automatically, but it won't have a good release message. Go the [release list](https://github.com/riverqueue/riverui/releases), find `$VERSION` and change the description to the release content in `CHANGELOG.md` (again, the build will have to finish first).


### PR DESCRIPTION
Fix a link to riverui releases index in development instructions.