### PR TITLE
more cleanly handle snoozed and retryable states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Job detail: handle snoozed jobs without erroring. [PR #104](https://github.com/riverqueue/riverui/pull/104).
+
 ## [0.3.0] - 2024-07-24
 
 ### Added
@@ -19,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add health check endpoints. [PR #61](https://github.com/riverqueue/riverui/pull/61).
-    - `GET /api/health-checks/complete` (Returns okay if the Go process is running and the database is healthy.)
-    - `GET /api/health-checks/minimal` (Returns okay as long as Go process is running.)
+  - `GET /api/health-checks/complete` (Returns okay if the Go process is running and the database is healthy.)
+  - `GET /api/health-checks/minimal` (Returns okay as long as Go process is running.)
 - Interpret some types of Postgres errors to be user facing to produce better error messages in the UI. [PR #76](https://github.com/riverqueue/riverui/pull/76).
 
 ## [0.1.1] - 2024-06-23

--- a/ui/src/components/JobTimeline.stories.tsx
+++ b/ui/src/components/JobTimeline.stories.tsx
@@ -13,9 +13,21 @@ export default meta;
 
 type Story = StoryObj<typeof JobTimeline>;
 
+export const Pending: Story = {
+  args: {
+    job: jobFactory.pending().build(),
+  },
+};
+
 export const Scheduled: Story = {
   args: {
     job: jobFactory.scheduled().build(),
+  },
+};
+
+export const ScheduledSnoozed: Story = {
+  args: {
+    job: jobFactory.scheduledSnoozed().build(),
   },
 };
 

--- a/ui/src/test/factories/job.ts
+++ b/ui/src/test/factories/job.ts
@@ -91,6 +91,9 @@ class JobFactory extends Factory<Job, object> {
 
   retryable() {
     const attemptedAt = faker.date.recent({ days: 0.01 });
+    const erroredAt = add(attemptedAt, {
+      seconds: faker.number.float({ min: 0.01, max: 95 }),
+    });
     return this.params({
       attempt: 9,
       attemptedAt,
@@ -116,14 +119,12 @@ class JobFactory extends Factory<Job, object> {
         attemptErrorFactory.build({ attempt: 8 }),
         attemptErrorFactory.build({ attempt: 9 }),
         attemptErrorFactory.build({
-          at: add(attemptedAt, {
-            seconds: faker.number.float({ min: 0.01, max: 95 }),
-          }),
+          at: erroredAt,
           attempt: 10,
         }),
       ],
       createdAt: sub(attemptedAt, { minutes: 31, seconds: 30 }),
-      scheduledAt: add(Date.now(), { minutes: 15, seconds: 22.5 }),
+      scheduledAt: add(erroredAt, { minutes: 15, seconds: 22.5 }),
       state: JobState.Retryable,
     });
   }
@@ -145,6 +146,22 @@ class JobFactory extends Factory<Job, object> {
     const scheduledAt = add(createdAt, { minutes: 30 });
 
     return this.params({
+      createdAt,
+      scheduledAt,
+      state: JobState.Scheduled,
+      tags: ["scheduled", "soon_in_future"],
+    });
+  }
+
+  scheduledSnoozed() {
+    const createdAt = faker.date.recent({ days: 0.001 });
+    const scheduledAt = add(createdAt, { minutes: 30 });
+
+    return this.params({
+      attemptedAt: add(createdAt, { seconds: 3 }),
+      attemptedBy: ["worker-1"],
+      attempt: 1,
+      errors: [],
       createdAt,
       scheduledAt,
       state: JobState.Scheduled,


### PR DESCRIPTION
Issue #103 highlights another tricky edge case with attempting to determine job duration, in this case for snoozed jobs. Upon snoozing, it's actually not possible to determine the job's runtime from any of the data stored as of now. There's no error record with a timestamp, no `finalized_at`, and no other value saved to indicate when the job stopped executing.

This was actually resulting in a crashing error in the UI in this case. I fixed it by reworking some of the logic so that we focus on isolating the easy-to-detect errored case first. I added a Storybook scenario for this case, as well as one for pending, and verified that all the `JobTimeline` states look correct with realistic data.

Fixes #103.