### PR TITLE
Upgrade to Go 1.23 + golangci-lint 1.60

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        go-version:
+          - "1.21"
+          - "1.22"
         postgres-version: [16, 15]
       fail-fast: false
     timeout-minutes: 5
@@ -42,11 +45,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Go
+      - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
-          check-latest: true
-          go-version-file: "./go.mod"
+          go-version: ${{ matrix.go-version }}
 
       - name: Display Go version
         run: go version
@@ -83,7 +85,7 @@ jobs:
     name: Go lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.59
+      GOLANGCI_LINT_VERSION: v1.60
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/riverui
 
 go 1.22
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require (
 	github.com/go-playground/validator/v10 v10.22.0

--- a/handler_api_endpoint.go
+++ b/handler_api_endpoint.go
@@ -183,7 +183,7 @@ func (a *jobDeleteEndpoint) Execute(ctx context.Context, req *jobDeleteRequest) 
 			jobID := int64(jobID)
 			_, err := a.client.JobDeleteTx(ctx, tx, jobID)
 			if err != nil {
-				if errors.Is(rivertype.ErrJobRunning, err) {
+				if errors.Is(err, rivertype.ErrJobRunning) {
 					return nil, apierror.NewBadRequest("Job %d is running and can't be deleted until it finishes.", jobID)
 				}
 				if errors.Is(err, river.ErrNotFound) {

--- a/internal/apiendpoint/api_endpoint.go
+++ b/internal/apiendpoint/api_endpoint.go
@@ -131,7 +131,7 @@ func executeAPIEndpoint[TReq any, TResp any](w http.ResponseWriter, r *http.Requ
 		}
 
 		if err := validate.StructCtx(ctx, &req); err != nil {
-			return apierror.NewBadRequest(validate.PublicFacingMessage(err))
+			return apierror.NewBadRequest(validate.PublicFacingMessage(err)) //nolint:govet
 		}
 
 		resp, err := execute(ctx, &req)


### PR DESCRIPTION
As we're doing in other River repos, upgrade to Go 1.23 and
golangci-lint 1.60 (for compatibility with Go 1.23).

Just in case we get this handler Go API working at some point, I've
added Go 1.23 as an additional version in the CI matrix, and left the
minimum Go version as 1.22 in `go.mod`. We can always change this later
in case it becomes painful to support both.