### PR TITLE
Add basic auth middleware for basic protection of web ui

### DIFF
--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -78,10 +78,12 @@ func initAndServe(ctx context.Context) int {
 	}
 
 	handlerOpts := &riverui.HandlerOpts{
-		Client: client,
-		DBPool: dbPool,
-		Logger: logger,
-		Prefix: pathPrefix,
+		Client:            client,
+		DBPool:            dbPool,
+		Logger:            logger,
+		Prefix:            pathPrefix,
+		BasicAuthUser:     os.Getenv("BASIC_AUTH_USER"),
+		BasicAuthPassword: os.Getenv("BASIC_AUTH_PASSWORD"),
 	}
 
 	server, err := riverui.NewServer(handlerOpts)

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,15 @@ $ docker pull ghcr.io/riverqueue/riverui:latest
 $ docker run -p 8080:8080 --env DATABASE_URL ghcr.io/riverqueue/riverui:latest
 ```
 
+### Environment variables
+
+- `DATABASE_URL=...` - define database url
+- `PORT=8080` - define listening port
+- `RIVER_DEBUG=true` - enable debugging logs
+- `CORS_ORIGINS=url1,url2` - define allowed CORS origins
+- `OTEL_ENABLED=true` - enable OTEL integration
+- `BASIC_AUTH_USER=admin`, `BASIC_AUTH_PASSWORD=changeme` - enable basic auth username/password
+
 ## Development
 
 See [developing River UI](./docs/development.md).


### PR DESCRIPTION
This should fix #111 in a very simple way.

- Adds new ENV variables for `BASIC_AUTH_USER` and `BASIC_AUT_PASSWORD` which both need to be defined, otherwise Basic Auth middleware will not be enabled.
- Documents existing found ENV variables