### PR TITLE
Use Go 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.21"
           - "1.22"
+          - "1.23"
         postgres-version: [16, 15]
       fail-fast: false
     timeout-minutes: 5

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,9 +13,6 @@ linters:
     - unused
 
   disable:
-    # disabled, but which we should enable after dropping support for Go 1.21 as
-    # they're kind of a good idea
-    - copyloopvar # lints to make sure that loop variables are _not_ captured since it's not required in Go 1.22+
     - intrange # encourages for loops to range over integers like `for i := range(5)` instead of a C-style for
 
     # disabled, but which we should enable with discussion


### PR DESCRIPTION
Following up on #112, this upgrades the project to test only Go 1.22 and 1.23 in CI.