### PR TITLE
rename go module to riverqueue.com/riverui

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,6 +61,7 @@ linters-settings:
       - Standard
       - Default
       - Prefix(github.com/riverqueue)
+      - Prefix(riverqueue.com/riverui)
 
   gomoddirectives:
     replace-local: true

--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -18,7 +18,8 @@ import (
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
-	"github.com/riverqueue/riverui"
+
+	"riverqueue.com/riverui"
 )
 
 var logger *slog.Logger //nolint:gochecknoglobals

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/riverqueue/riverui
+module riverqueue.com/riverui
 
 go 1.22
 

--- a/handler.go
+++ b/handler.go
@@ -21,9 +21,10 @@ import (
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
-	"github.com/riverqueue/riverui/internal/apiendpoint"
-	"github.com/riverqueue/riverui/internal/apimiddleware"
-	"github.com/riverqueue/riverui/internal/dbsqlc"
+
+	"riverqueue.com/riverui/internal/apiendpoint"
+	"riverqueue.com/riverui/internal/apimiddleware"
+	"riverqueue.com/riverui/internal/dbsqlc"
 )
 
 type DBTXWithBegin interface {

--- a/handler_api_endpoint.go
+++ b/handler_api_endpoint.go
@@ -19,11 +19,12 @@ import (
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
-	"github.com/riverqueue/riverui/internal/apiendpoint"
-	"github.com/riverqueue/riverui/internal/apierror"
-	"github.com/riverqueue/riverui/internal/dbsqlc"
-	"github.com/riverqueue/riverui/internal/querycacher"
-	"github.com/riverqueue/riverui/internal/util/pgxutil"
+
+	"riverqueue.com/riverui/internal/apiendpoint"
+	"riverqueue.com/riverui/internal/apierror"
+	"riverqueue.com/riverui/internal/dbsqlc"
+	"riverqueue.com/riverui/internal/querycacher"
+	"riverqueue.com/riverui/internal/util/pgxutil"
 )
 
 // A bundle of common utilities needed for many API endpoints.

--- a/handler_api_endpoint_test.go
+++ b/handler_api_endpoint_test.go
@@ -16,9 +16,10 @@ import (
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
-	"github.com/riverqueue/riverui/internal/apierror"
-	"github.com/riverqueue/riverui/internal/riverinternaltest"
-	"github.com/riverqueue/riverui/internal/riverinternaltest/testfactory"
+
+	"riverqueue.com/riverui/internal/apierror"
+	"riverqueue.com/riverui/internal/riverinternaltest"
+	"riverqueue.com/riverui/internal/riverinternaltest/testfactory"
 )
 
 type setupEndpointTestBundle struct {

--- a/handler_test.go
+++ b/handler_test.go
@@ -14,8 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
-	"github.com/riverqueue/riverui/internal/riverinternaltest"
-	"github.com/riverqueue/riverui/internal/riverinternaltest/testfactory"
+
+	"riverqueue.com/riverui/internal/riverinternaltest"
+	"riverqueue.com/riverui/internal/riverinternaltest/testfactory"
 )
 
 func TestNewHandlerIntegration(t *testing.T) {

--- a/internal/apiendpoint/api_endpoint.go
+++ b/internal/apiendpoint/api_endpoint.go
@@ -15,8 +15,8 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 
-	"github.com/riverqueue/riverui/internal/apierror"
-	"github.com/riverqueue/riverui/internal/validate"
+	"riverqueue.com/riverui/internal/apierror"
+	"riverqueue.com/riverui/internal/validate"
 )
 
 // Endpoint is a struct that should be embedded on an API endpoint, and which

--- a/internal/apiendpoint/api_endpoint_test.go
+++ b/internal/apiendpoint/api_endpoint_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
-	"github.com/riverqueue/riverui/internal/apierror"
-	"github.com/riverqueue/riverui/internal/riverinternaltest"
+	"riverqueue.com/riverui/internal/apierror"
+	"riverqueue.com/riverui/internal/riverinternaltest"
 )
 
 func TestMountAndServe(t *testing.T) {

--- a/internal/apierror/api_error_test.go
+++ b/internal/apierror/api_error_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/riverqueue/riverui/internal/riverinternaltest"
+	"riverqueue.com/riverui/internal/riverinternaltest"
 )
 
 func TestAPIError(t *testing.T) {

--- a/internal/querycacher/query_cacher.go
+++ b/internal/querycacher/query_cacher.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
-	"github.com/riverqueue/riverui/internal/dbsqlc"
+
+	"riverqueue.com/riverui/internal/dbsqlc"
 )
 
 // QueryCacher executes a database query periodically and caches the result. The
@@ -131,7 +132,7 @@ func (s *QueryCacher[TRes]) Start(ctx context.Context) error {
 //
 // So this:
 //
-//	QueryCacher[[]*github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]
+//	QueryCacher[[]*riverqueue.com/riverui/internal/dbsqlc.JobCountByStateRow]
 //
 // Becomes this:
 //

--- a/internal/querycacher/query_cacher_test.go
+++ b/internal/querycacher/query_cacher_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
-	"github.com/riverqueue/riverui/internal/dbsqlc"
-	"github.com/riverqueue/riverui/internal/riverinternaltest"
-	"github.com/riverqueue/riverui/internal/riverinternaltest/testfactory"
+
+	"riverqueue.com/riverui/internal/dbsqlc"
+	"riverqueue.com/riverui/internal/riverinternaltest"
+	"riverqueue.com/riverui/internal/riverinternaltest/testfactory"
 )
 
 func TestQueryCacher(t *testing.T) {
@@ -118,8 +119,8 @@ func TestSimplifyArchetypeLogName(t *testing.T) {
 	require.Equal(t, "Simple[[]*int]", simplifyArchetypeLogName("Simple[[]*int]"))
 
 	// More realistic examples.
-	require.Equal(t, "QueryCacher[dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
-	require.Equal(t, "QueryCacher[*dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[*github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
-	require.Equal(t, "QueryCacher[[]dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[[]github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
-	require.Equal(t, "QueryCacher[[]*dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[[]*github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
+	require.Equal(t, "QueryCacher[dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[riverqueue.com/riverui/internal/dbsqlc.JobCountByStateRow]"))
+	require.Equal(t, "QueryCacher[*dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[*riverqueue.com/riverui/internal/dbsqlc.JobCountByStateRow]"))
+	require.Equal(t, "QueryCacher[[]dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[[]riverqueue.com/riverui/internal/dbsqlc.JobCountByStateRow]"))
+	require.Equal(t, "QueryCacher[[]*dbsqlc.JobCountByStateRow]", simplifyArchetypeLogName("QueryCacher[[]*riverqueue.com/riverui/internal/dbsqlc.JobCountByStateRow]"))
 }

--- a/internal/util/pgxutil/db_util_test.go
+++ b/internal/util/pgxutil/db_util_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
-	"github.com/riverqueue/riverui/internal/riverinternaltest"
+	"riverqueue.com/riverui/internal/riverinternaltest"
 )
 
 func TestWithTx(t *testing.T) {


### PR DESCRIPTION
The new vanity module name will enable a packaged Go module to be shipped that includes bundled static assets for the UI.