### PR TITLE
Improve server/handler APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The module name was changed from `github.com/riverqueue/riverui` to `riverqueue.com/riverui`. This change was made to facilitate bundling of module releases that include vendored frontend assets, which will enable the embedded `Handler` type to be usable by anybody who `go get` installs the module without requiring a complex build setup.
+- Rename `HandlerOpts` to `ServerOpts` for consistency. The `Handler` type was renamed to `Server` in [PR #108](https://github.com/riverqueue/riverui/pull/108) but the opts type was not renamed until now. [PR #133](https://github.com/riverqueue/riverui/pull/133).
+- Implement `http.Handler` on `Server` type via a `ServeHTTP` method so that it can be used directly without needing to call `.Handler()` on it. [PR #133](https://github.com/riverqueue/riverui/pull/133).
+- Directly specify `DB` interface type and rename it. Avoids relying on embedding a type from an internal package. [PR #133](https://github.com/riverqueue/riverui/pull/133).
 
 ### Removed
 

--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -81,9 +81,9 @@ func initAndServe(ctx context.Context) int {
 		return 1
 	}
 
-	handlerOpts := &riverui.HandlerOpts{
+	handlerOpts := &riverui.ServerOpts{
 		Client:  client,
-		DBPool:  dbPool,
+		DB:      dbPool,
 		DevMode: devMode,
 		LiveFS:  liveFS,
 		Logger:  logger,
@@ -101,7 +101,7 @@ func initAndServe(ctx context.Context) int {
 		return 1
 	}
 
-	logHandler := sloghttp.Recovery(server.Handler())
+	logHandler := sloghttp.Recovery(server)
 	config := sloghttp.Config{
 		WithSpanID:  otelEnabled,
 		WithTraceID: otelEnabled,

--- a/handler_api_endpoint.go
+++ b/handler_api_endpoint.go
@@ -31,7 +31,7 @@ import (
 type apiBundle struct {
 	archetype *baseservice.Archetype
 	client    *river.Client[pgx.Tx]
-	dbPool    DBTXWithBegin
+	dbPool    DB
 	logger    *slog.Logger
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -46,9 +46,9 @@ func TestNewHandlerIntegration(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { tx.Rollback(ctx) })
 
-			server, err := NewServer(&HandlerOpts{
+			server, err := NewServer(&ServerOpts{
 				Client:  client,
-				DBPool:  tx,
+				DB:      tx,
 				DevMode: true,
 				LiveFS:  true,
 				Logger:  logger,
@@ -65,7 +65,7 @@ func TestNewHandlerIntegration(t *testing.T) {
 
 			t.Logf("--> %s %s", method, path)
 
-			server.Handler().ServeHTTP(recorder, req)
+			server.ServeHTTP(recorder, req)
 
 			status := recorder.Result().StatusCode //nolint:bodyclose
 			t.Logf("Response status: %d", status)


### PR DESCRIPTION
* Rename `DBTXWithBegin` interface type to `DB`, and avoid defining it via an internal package type in favor of an inline definition.
* Rename `HandlerOpts` to `ServerOpts` since it's used by the `NewServer` constructor.
* Implement `ServeHTTP()` / `http.Handler` directly on the `Server` type so that users don't need to jump through a `.Handler()` method when mounting it into an HTTP mux.

Fixes #130. Fixes #131. Fixes #132.