### PR TITLE
fix: link to the development doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,4 +48,4 @@ The `riverui` command accepts a `-prefix` arg to set a path prefix on both the A
 
 ## Development
 
-See [developing River UI](./docs/development.md).
+See [developing River UI](./development.md).


### PR DESCRIPTION
When rendered on the [main Github page](https://github.com/riverqueue/riverui) at least, I have a [double docs link](https://github.com/riverqueue/riverui/blob/master/docs/docs/development.md) which give a 404 - Not Found response.