### PR TITLE
Fix ListenAndServe() error check

### DIFF
--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -116,7 +116,7 @@ func initAndServe(ctx context.Context) int {
 
 	log.Printf("starting server on %s", srv.Addr)
 
-	if err = srv.ListenAndServe(); err != nil && errors.Is(err, http.ErrServerClosed) {
+	if err = srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.ErrorContext(ctx, "error from ListenAndServe", slog.String("error", err.Error()))
 		return 1
 	}


### PR DESCRIPTION
Pretty sure that should have been a !erorrs.Is() check.

Before:

	% DATABASE_URL=postgresql://aleph:aleph@127.0.0.1/aleph riverui
	2024/08/31 23:18:50 starting server on :8080
	[immediately exits]

	% echo $?
	0

After:

	% DATABASE_URL=postgresql://aleph:aleph@127.0.0.1/aleph riverui
	2024/08/31 23:20:02 starting server on :8080
	time=2024-08-31T23:20:02.581+01:00 level=ERROR msg="error from ListenAndServe" error="listen tcp :8080: bind: address already in use"

	% echo $?
	1
