### PR TITLE
Fix broken dropdowns, prepare v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-09-01
+
+### Fixed
+
+- Downgrade `@headlessui/react` version to v2.1.1 to fix issues with listbox menus (refresh settings and theme selector). [PR #139](https://github.com/riverqueue/riverui/pull/139).
+
 ## [0.5.0] - 2024-08-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
-        "@headlessui/react": "^2.1.3",
+        "@headlessui/react": "2.1.1",
         "@headlessui/tailwindcss": "^0.2.1",
         "@heroicons/react": "^2.1.5",
         "@tailwindcss/typography": "^0.5.14",
@@ -2585,14 +2585,15 @@
       "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
     },
     "node_modules/@headlessui/react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.3.tgz",
-      "integrity": "sha512-Nt+NlnQbVvMHVZ/QsST6DNyfG8VWqjOYY3eZpp0PrRKpmZw+pzhwQ1F6wtNaW4jnudeC2a5MJC70vbGVcETNIg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-808gVNUbRDbDR3GMNPHy+ON0uvR8b9H7IA+Q2UbhOsNCIjgwuwb2Iuv8VPT/1AW0UzLX8g10tN6LhF15GaUJCQ==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
         "@react-aria/focus": "^3.17.1",
         "@react-aria/interactions": "^3.21.3",
-        "@tanstack/react-virtual": "^3.8.1"
+        "@tanstack/react-virtual": "3.5.0"
       },
       "engines": {
         "node": ">=10"
@@ -4375,11 +4376,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.10.1.tgz",
-      "integrity": "sha512-h5kNeE+yQwspjl9E3sJ3UYQu/MuspNOBT5cVdc+NA0uU9B1XSkxbzp86teV3arMDVcQ4ESExqs4JyIirYAMcuA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.5.0.tgz",
+      "integrity": "sha512-rtvo7KwuIvqK9zb0VZ5IL7fiJAEnG+0EiFZz8FUOs+2mhGqdGmjKIaT1XU7Zq0eFqL0jonLlhbayJI/J2SA/Bw==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.10.1"
+        "@tanstack/virtual-core": "3.5.0"
       },
       "funding": {
         "type": "github",
@@ -4503,9 +4505,10 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.10.1.tgz",
-      "integrity": "sha512-JDi3wU1HIxuxx8BgD7Ix8IXlelCKdTJIh9c0qBs+QXHdix3mjMbkXI3wOq0TuCx1w1RGgzZue34QrM/NPdp/sw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.5.0.tgz",
+      "integrity": "sha512-KnPRCkQTyqhanNC0K63GBG3wA8I+D1fQuVnAvcBF8f13akOKeQp1gSbu6f77zCxhEk727iV5oQnbHLYzHrECLg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@dagrejs/dagre": "^1.1.4",
-    "@headlessui/react": "^2.1.3",
+    "@headlessui/react": "2.1.1",
     "@headlessui/tailwindcss": "^0.2.1",
     "@heroicons/react": "^2.1.5",
     "@tailwindcss/typography": "^0.5.14",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         manualChunks: {
           // use vite-bundle-visualizer to find good candidates for manual chunks:
           dagrejs: ["@dagrejs/dagre"],
+          headlessui: ["@headlessui/react"],
           "react-dom": ["react-dom"],
           reactflow: ["reactflow"],
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         },
       },
     },
+    sourcemap: true,
     target: "esnext",
   },
   plugins: [react(), TanStackRouterVite(), tsconfigPaths()],


### PR DESCRIPTION
The bug reported in #138 appears to have been caused by a headless UI upgrade (https://github.com/tailwindlabs/headlessui/issues/3386), and only manifests itself in production builds. Downgrading the dependency to v2.1.1 fixes it.

I also turned on sourcemap builds for prod, because these might make debugging future issues easier and they'll only get loaded when opening the devtools anyway.

Preparing a v0.5.1 release as part of this fix to ship it ASAP.