### PR TITLE
feat: add possibility to specify server host address

### DIFF
--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -58,6 +58,7 @@ func initAndServe(ctx context.Context) int {
 	corsOrigins := strings.Split(corsOriginString, ",")
 	dbURL := mustEnv("DATABASE_URL")
 	otelEnabled := os.Getenv("OTEL_ENABLED") == "true"
+	host := os.Getenv("HOST")
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
@@ -109,7 +110,7 @@ func initAndServe(ctx context.Context) int {
 	wrappedHandler := sloghttp.NewWithConfig(logger, config)(corsHandler.Handler(logHandler))
 
 	srv := &http.Server{
-		Addr:              ":" + port,
+		Addr:              host + ":" + port,
 		Handler:           wrappedHandler,
 		ReadHeaderTimeout: 5 * time.Second,
 	}


### PR DESCRIPTION
It is already possible to specify the server port with the `PORT` env variable. This PR adds the possibility to also specify the host variable to avoid listening to all IP addresses.

This is a nice to have when the container is launched in [host network](https://docs.docker.com/engine/network/tutorials/host/).