### PR TITLE
Small code clean up for env vars + CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow `HOST` variable to specify specific host variable to bind to. [PR #157](https://github.com/riverqueue/riverui/pull/157).
+
 ## [0.5.3] - 2024-09-05
+
+### Fixed
 
 - Remove `.gitignore` from Go module bundle because it messes with vendoring in some situations. Thanks [Pedro Henrique](https://github.com/crossworth)! 🙏🏻 [PR #149](https://github.com/riverqueue/riverui/pull/149).
 

--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"flag"
@@ -54,15 +55,13 @@ func initAndServe(ctx context.Context) int {
 	}
 	pathPrefix = riverui.NormalizePathPrefix(pathPrefix)
 
-	corsOriginString := os.Getenv("CORS_ORIGINS")
-	corsOrigins := strings.Split(corsOriginString, ",")
-	dbURL := mustEnv("DATABASE_URL")
-	otelEnabled := os.Getenv("OTEL_ENABLED") == "true"
-	host := os.Getenv("HOST")
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
+	var (
+		corsOrigins = strings.Split(os.Getenv("CORS_ORIGINS"), ",")
+		dbURL       = mustEnv("DATABASE_URL")
+		host        = os.Getenv("HOST") // may be left empty to bind to all local interfaces
+		otelEnabled = os.Getenv("OTEL_ENABLED") == "true"
+		port        = cmp.Or(os.Getenv("PORT"), "8080")
+	)
 
 	dbPool, err := getDBPool(ctx, dbURL)
 	if err != nil {


### PR DESCRIPTION
Follows up #157 with some small clean up to how env vars are handled, a
doc string making it clear that `HOST` is not require and may be left
empty, along with a CHANGELOG entry.