### PR TITLE
add log level environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `RIVER_LOG_LEVEL` env for env-based configuration of River UI's log level. Thank you [Taras Turchenko](https://github.com/TArch64)! 🙏🏻 [PR #183](https://github.com/riverqueue/riverui/pull/183).
+
 ### Changed
 
 - Allow `HOST` variable to specify specific host variable to bind to. [PR #157](https://github.com/riverqueue/riverui/pull/157).

--- a/cmd/riverui/logger.go
+++ b/cmd/riverui/logger.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+var logger *slog.Logger //nolint:gochecknoglobals
+
+func initLogger() {
+	options := &slog.HandlerOptions{Level: getLogLevel()}
+	logger = slog.New(slog.NewTextHandler(os.Stdout, options))
+}
+
+func getLogLevel() slog.Level {
+	if isDebug() {
+		return slog.LevelDebug
+	}
+
+	env := strings.ToLower(os.Getenv("RIVER_LOG_LEVEL"))
+
+	switch env {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	}
+
+	return slog.LevelInfo
+}
+
+func isDebug() bool {
+	debugEnv := os.Getenv("RIVER_DEBUG")
+	return debugEnv == "1" || debugEnv == "true"
+}

--- a/cmd/riverui/logger.go
+++ b/cmd/riverui/logger.go
@@ -14,7 +14,8 @@ func initLogger() {
 }
 
 func getLogLevel() slog.Level {
-	if isDebug() {
+	debugEnv := os.Getenv("RIVER_DEBUG")
+	if debugEnv == "1" || debugEnv == "true" {
 		return slog.LevelDebug
 	}
 
@@ -27,12 +28,7 @@ func getLogLevel() slog.Level {
 		return slog.LevelWarn
 	case "error":
 		return slog.LevelError
+	default:
+		return slog.LevelInfo
 	}
-
-	return slog.LevelInfo
-}
-
-func isDebug() bool {
-	debugEnv := os.Getenv("RIVER_DEBUG")
-	return debugEnv == "1" || debugEnv == "true"
 }

--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -23,17 +23,9 @@ import (
 	"riverqueue.com/riverui"
 )
 
-var logger *slog.Logger //nolint:gochecknoglobals
-
 func main() {
 	ctx := context.Background()
-
-	if os.Getenv("RIVER_DEBUG") == "1" || os.Getenv("RIVER_DEBUG") == "true" {
-		logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	} else {
-		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
-	}
-
+	initLogger()
 	os.Exit(initAndServe(ctx))
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,15 @@ $ docker run -p 8080:8080 --env DATABASE_URL ghcr.io/riverqueue/riverui:latest
 
 The `riverui` command accepts a `-prefix` arg to set a path prefix on both the API and static assets. When executing the Docker image, this is accepted as a `PATH_PREFIX` env.
 
+### Logging Configuration
+
+The `riverui` command utilizes the `RIVER_LOG_LEVEL` environment variable to configure its logging level. The following values are accepted:
+
+* `DEBUG`
+* `INFO` (default)
+* `WARN`
+* `ERROR`
+
 ## Development
 
 See [developing River UI](./development.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,10 +50,10 @@ The `riverui` command accepts a `-prefix` arg to set a path prefix on both the A
 
 The `riverui` command utilizes the `RIVER_LOG_LEVEL` environment variable to configure its logging level. The following values are accepted:
 
-* `DEBUG`
-* `INFO` (default)
-* `WARN`
-* `ERROR`
+* `debug`
+* `info` (default)
+* `warn`
+* `error`
 
 ## Development
 


### PR DESCRIPTION
Added `RIVER_LOG_LEVEL` environment variable to make possible configuring log level using docker images. Added support of all levels defined in `slog.Level` using their name both in lower and upper case.

Related links:
- https://github.com/riverqueue/riverui/discussions/161