### PR TITLE
Change `HOST` to `RIVER_HOST`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Allow `HOST` variable to specify specific host variable to bind to. [PR #157](https://github.com/riverqueue/riverui/pull/157).
+- Allow `RIVER_HOST` variable to specify specific host variable to bind to. [PR #157](https://github.com/riverqueue/riverui/pull/157).
 
 ## [0.5.3] - 2024-09-05
 

--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -50,7 +50,7 @@ func initAndServe(ctx context.Context) int {
 	var (
 		corsOrigins = strings.Split(os.Getenv("CORS_ORIGINS"), ",")
 		dbURL       = mustEnv("DATABASE_URL")
-		host        = os.Getenv("HOST") // may be left empty to bind to all local interfaces
+		host        = os.Getenv("RIVER_HOST") // may be left empty to bind to all local interfaces
 		otelEnabled = os.Getenv("OTEL_ENABLED") == "true"
 		port        = cmp.Or(os.Getenv("PORT"), "8080")
 	)


### PR DESCRIPTION
I realized after merging #157 that it's probably not appropriate to use
the env var `HOST` because it's so ubiquitous and easily conflated with
a value intended for a different, non-River use. For example, `HOST` is
set automatically on every computer running Mac OS, and likely other
operating systems as well.

Since we're prefixing variables with `RIVER_` for other purposes like
`RIVER_LOG_LEVEL` in #183 anyway, change this to `RIVER_HOST`.

I think we should probably prefix some of the other env vars that
River UI uses as well (e.g. `DEV` should maybe be `RIVER_DEV`), but
after starting to do that I gave up on it for now since there were a
couple where the right thing to do (prefix versus not) wasn't totally
clear.