### PR TITLE
add basic http auth middleware

### DIFF
--- a/cmd/riverui/auth_middleware.go
+++ b/cmd/riverui/auth_middleware.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"os"
+)
+
+func installAuthMiddleware(next http.Handler) http.Handler {
+	username := os.Getenv("RIVER_BASIC_AUTH_USER")
+	password := os.Getenv("RIVER_BASIC_AUTH_PASS")
+
+	if username == "" || password == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if isReqAuthorized(req, username, password) {
+			next.ServeHTTP(res, req)
+			return
+		}
+
+		res.Header().Set("WWW-Authenticate", "Basic realm=\"riverui\"")
+		http.Error(res, "Unauthorized", http.StatusUnauthorized)
+	})
+}
+
+func isReqAuthorized(req *http.Request, username, password string) bool {
+	reqUsername, reqPassword, ok := req.BasicAuth()
+
+	return ok &&
+		subtle.ConstantTimeCompare([]byte(reqUsername), []byte(username)) == 1 &&
+		subtle.ConstantTimeCompare([]byte(reqPassword), []byte(password)) == 1
+}

--- a/cmd/riverui/cors_middleware.go
+++ b/cmd/riverui/cors_middleware.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/rs/cors"
+)
+
+func installCorsMiddleware(next http.Handler) http.Handler {
+	origins := strings.Split(os.Getenv("CORS_ORIGINS"), ",")
+
+	handler := cors.New(cors.Options{
+		AllowedMethods: []string{"GET", "HEAD", "POST", "PUT"},
+		AllowedOrigins: origins,
+	})
+
+	return handler.Handler(next)
+}

--- a/cmd/riverui/logger_middleware.go
+++ b/cmd/riverui/logger_middleware.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	sloghttp "github.com/samber/slog-http"
+	"net/http"
+	"os"
+)
+
+func installLoggerMiddleware(next http.Handler) http.Handler {
+	otelEnabled := os.Getenv("OTEL_ENABLED") == "true"
+
+	return sloghttp.NewWithConfig(logger, sloghttp.Config{
+		WithSpanID:  otelEnabled,
+		WithTraceID: otelEnabled,
+	})(next)
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,11 @@ The `riverui` command utilizes the `RIVER_LOG_LEVEL` environment variable to con
 * `warn`
 * `error`
 
+### Basic HTTP Authentication
+
+The `riverui` supports basic HTTP authentication to protect access to the UI.
+To enable it, set the `RIVER_BASIC_AUTH_USER` and `RIVER_BASIC_AUTH_PASS` environment variables.
+
 ## Development
 
 See [developing River UI](./development.md).


### PR DESCRIPTION
Added basic HTTP auth middleware to riverui cmd so it can be used to setup auth when using docker image. Also rewrote adding CORS & logger middlewares in the same way

Resolving [this](https://github.com/riverqueue/riverui/issues/111) issue for docker images