### PR TITLE
Prepare release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2024-12-16
+
 ### Added
 
 - Add support for basic auth to the riverui executable. Thanks [Taras Turchenko](https://github.com/TArch64)! [PR #241](https://github.com/riverqueue/riverui/pull/241).


### PR DESCRIPTION
Shipping largely to get the changes from #253 to make sure there's a
River UI release out there that's compatible with River 0.14.3, but also
includes basic auth from #241.