### PR TITLE
Use `startstop.StartAll` helper to start services

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -203,11 +203,8 @@ func (s *Server) Start(ctx context.Context) error {
 		return nil
 	}
 
-	// TODO: Replace with startstop.StartAll when possible.
-	for _, service := range s.services {
-		if err := service.Start(ctx); err != nil {
-			return err
-		}
+	if err := startstop.StartAll(ctx, s.services...); err != nil {
+		return err
 	}
 
 	go func() {


### PR DESCRIPTION
While working on something else just noticed there was a comment to
switch over to `startstop.StartAll` for starting all services once that
was available through `rivershared`. It's in there now, so switch over.