### PR TITLE
queue table: prevent reflow on pause/unpause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow `PG*` env vars as an alternative to `DATABASE_URL`. [PR #256](https://github.com/riverqueue/riverui/pull/256).
 
+### Fixed
+
+- Queue list columns no longer resize when pausing/resuming a queue. [PR #286](https://github.com/riverqueue/riverui/pull/286).
+
 ## [0.7.0] - 2024-12-16
 
 ### Added

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -26,7 +26,7 @@ const QueueList = ({
 
       <div className="mx-auto px-4 sm:px-6 lg:px-8">
         <div className="-mx-4 mt-8 sm:-mx-0">
-          <table className="min-w-full divide-y divide-slate-300 dark:divide-slate-700">
+          <table className="min-w-full table-fixed divide-y divide-slate-300 dark:divide-slate-700">
             <thead>
               <tr>
                 <th
@@ -55,11 +55,14 @@ const QueueList = ({
                 </th>
                 <th
                   scope="col"
-                  className="table-cell px-3 py-2.5 text-left text-sm font-semibold text-slate-900 dark:text-slate-100"
+                  className="table-cell w-20 min-w-20 px-3 py-2 text-left text-sm font-semibold text-slate-900 dark:text-slate-100"
                 >
                   Status
                 </th>
-                <th scope="col" className="relative py-2.5 pl-3 pr-4 sm:pr-0">
+                <th
+                  scope="col"
+                  className="relative w-12 py-2.5 pl-3 pr-4 sm:pr-0"
+                >
                   <span className="sr-only">Controls</span>
                 </th>
               </tr>
@@ -103,10 +106,10 @@ const QueueList = ({
                   <td className="hidden px-3 py-2 text-right text-sm text-slate-500 dark:text-slate-300 sm:table-cell">
                     {queue.countRunning}
                   </td>
-                  <td className="table-cell px-3 py-2 text-sm text-slate-500 dark:text-slate-300">
+                  <td className="table-cell w-20 min-w-20 px-3 py-2 text-sm text-slate-500 dark:text-slate-300">
                     {queue.pausedAt ? "Paused" : "Active"}
                   </td>
-                  <td className="py-2 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
+                  <td className="w-12 py-2 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
                     <button
                       className="rounded-md bg-white px-2 py-1 text-sm font-semibold text-slate-900 shadow-xs ring-1 ring-inset ring-slate-300 hover:bg-slate-50 dark:bg-white/10 dark:text-white dark:ring-slate-700 dark:hover:bg-white/20"
                       onClick={


### PR DESCRIPTION
Because all of the widths in this table were automatically calculated, pausing just a single queue causes the width of the status column to change (`Paused` is longer than `Active`).

Fix the widths of this column and the control button next to it to avoid this issue.

Suggested by @yurivish :pray:

### Before

![queue-table-before](https://github.com/user-attachments/assets/a3414b28-a5c2-44cc-bb68-f0471401df62)

### After

![queue-table-after](https://github.com/user-attachments/assets/e04fcf2d-a9d1-451a-b7f8-153a48b0307b)