### PR TITLE
use Go 1.23 + 1.24 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
           - "1.23"
+          - "1.24"
         postgres-version: [16, 15]
       fail-fast: false
     timeout-minutes: 5


### PR DESCRIPTION
#311 is failing because of the required Go v1.23 in `golang.org/x/text@v0.23.0`. This project was already updated to require a minimum of Go v1.23 in #307, however we didn't update CI to use only v1.23 and v1.24—hence the CI failures.