### PR TITLE
remove sourcemaps from bundled release, other JS config files

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -66,7 +66,8 @@ jobs:
         shell: sh
 
       - name: Build JS 🏗️
-        run: npm exec vite build
+        #  exclude sourcemaps from packaged Go releases:
+        run: npm exec vite build -- --sourcemap false
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -129,6 +130,7 @@ jobs:
         # Remove all files that we don't want to end up in the final mod release .zip file, including:
         # * node_modules
         # * UI source files, .json, .js
+        # * UI config files for eslint, typescript, vite, etc.
         # * .gitignore, because it messes with Go vendoring
         run: |
           rm -r \
@@ -138,10 +140,14 @@ jobs:
             .stylelintignore \
             .vscode \
             eslint.config.mjs \
+            Makefile \
             node_modules \
             package-lock.json \
             package.json \
-            src
+            tsconfig.json \
+            tsconfig.node.json \
+            src \
+            vite.config.ts
 
       - name: Package module
         # if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
I took a glance at the latest packaged release to make sure it was trimmed down. You can do that with:

```bash
curl https://proxy.golang.org/riverqueue.com/riverui/@v/v0.9.0.zip -o ~/Downloads/riverui-v0.9.0.zip
```

I realized we were including not only bundled JS assets, but also the much larger sourcemap files. These push the zipped release to over 1MB instead of something much smaller.

I adjusted the build process to slim down the bundle size by excluding large JS sourcemap files from the packaged releases. Also removed other JS config files that don't need to be there after the frontend is built.