### PR TITLE
(bugfix) Supports errors = undefined in apiAttemptErrorsToAttemptErrors

### DIFF
--- a/src/services/jobs.ts
+++ b/src/services/jobs.ts
@@ -110,6 +110,10 @@ export const apiJobToJob = (job: JobFromAPI): Job => ({
 const apiAttemptErrorsToAttemptErrors = (
   errors: AttemptErrorFromAPI[],
 ): AttemptError[] => {
+  if (!errors) {
+    return [];
+  }
+
   return errors.map((error) => ({
     at: new Date(error.at),
     attempt: error.attempt,


### PR DESCRIPTION
Fixes #347 

I've decided not to decouple `apiJobToJob` as we use it for both `getJob` and `listJobs` for now. So simple check for empty (non-present) `errors` array is enough. 

Works just fine.
