### PR TITLE
fix frontend type issues with split Job type

### DIFF
--- a/src/components/JobList.stories.ts
+++ b/src/components/JobList.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { JobState } from "@services/types";
-import { jobFactory } from "@test/factories/job";
+import { jobMinimalFactory } from "@test/factories/job";
 
 import JobList from "./JobList";
 
@@ -16,7 +16,7 @@ type Story = StoryObj<typeof JobList>;
 
 export const Running: Story = {
   args: {
-    jobs: jobFactory.running().buildList(10),
+    jobs: jobMinimalFactory.running().buildList(10),
     setJobRefetchesPaused: () => {},
     state: JobState.Running,
   },

--- a/src/components/JobList.tsx
+++ b/src/components/JobList.tsx
@@ -17,7 +17,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { useSelected } from "@hooks/use-selected";
 import { useShiftSelected } from "@hooks/use-shift-selected";
-import { Job } from "@services/jobs";
+import { JobMinimal } from "@services/jobs";
 import { StatesAndCounts } from "@services/states";
 import { JobState } from "@services/types";
 import { Link } from "@tanstack/react-router";
@@ -39,7 +39,7 @@ const states: { [key in JobState]: string } = {
   [JobState.Scheduled]: "text-rose-400 bg-rose-400/10",
 };
 
-const timestampForRelativeDisplay = (job: Job): Date => {
+const timestampForRelativeDisplay = (job: JobMinimal): Date => {
   switch (job.state) {
     case JobState.Completed:
       return job.finalizedAt ? job.finalizedAt : new Date();
@@ -50,7 +50,7 @@ const timestampForRelativeDisplay = (job: Job): Date => {
   }
 };
 
-const JobTimeDisplay = ({ job }: { job: Job }): React.JSX.Element => {
+const JobTimeDisplay = ({ job }: { job: JobMinimal }): React.JSX.Element => {
   return (
     <span>
       <RelativeTimeFormatter
@@ -64,7 +64,7 @@ const JobTimeDisplay = ({ job }: { job: Job }): React.JSX.Element => {
 
 type JobListItemProps = {
   checked: boolean;
-  job: Job;
+  job: JobMinimal;
   onChangeSelect: (
     checked: boolean,
     event: React.ChangeEvent<HTMLInputElement>,
@@ -159,7 +159,7 @@ export type JobRowsProps = {
   canShowMore: boolean;
   deleteJobs: (jobIDs: bigint[]) => void;
   initialFilters?: Filter[];
-  jobs: Job[];
+  jobs: JobMinimal[];
   onFiltersChange?: (filters: Filter[]) => void;
   retryJobs: (jobIDs: bigint[]) => void;
   setJobRefetchesPaused: (value: boolean) => void;
@@ -174,7 +174,7 @@ type JobListProps = {
   canShowMore: boolean;
   deleteJobs: (jobIDs: bigint[]) => void;
   initialFilters?: Filter[];
-  jobs: Job[];
+  jobs: JobMinimal[];
   loading?: boolean;
   onFiltersChange?: (filters: Filter[]) => void;
   retryJobs: (jobIDs: bigint[]) => void;

--- a/src/routes/jobs/index.tsx
+++ b/src/routes/jobs/index.tsx
@@ -5,7 +5,7 @@ import { defaultValues, jobSearchSchema } from "@routes/jobs/index.schema";
 import {
   cancelJobs,
   deleteJobs,
-  Job,
+  JobMinimal,
   listJobs,
   ListJobsKey,
   listJobsKey,
@@ -312,9 +312,9 @@ const jobsQueryOptions = (
   opts?: { pauseRefetches: boolean; refetchInterval: number },
 ) => {
   const keepPreviousDataUnlessStateChanged: PlaceholderDataFunction<
-    Job[],
+    JobMinimal[],
     Error,
-    Job[],
+    JobMinimal[],
     ListJobsKey
   > = (previousData, previousQuery) => {
     if (!previousQuery) return undefined;

--- a/src/test/factories/job.ts
+++ b/src/test/factories/job.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { AttemptError, Job } from "@services/jobs";
+import { AttemptError, Job, JobMinimal } from "@services/jobs";
 import { JobState } from "@services/types";
 import { add, sub } from "date-fns";
 import { Factory } from "fishery";
@@ -26,6 +26,52 @@ export const attemptErrorFactory = AttemptErrorFactory.define(({ params }) => {
     error: "Failed yet again with some Go message",
     trace: sampleTrace,
   };
+});
+
+// Helper type to extract only JobMinimal fields from Job:
+type JobMinimalFields = Pick<Job, keyof JobMinimal>;
+
+class JobMinimalFactory extends Factory<JobMinimal, object> {
+  available() {
+    return this.params(jobFactory.available().build());
+  }
+
+  cancelled() {
+    return this.params(jobFactory.cancelled().build());
+  }
+
+  completed() {
+    return this.params(jobFactory.completed().build());
+  }
+
+  discarded() {
+    return this.params(jobFactory.discarded().build());
+  }
+
+  pending() {
+    return this.params(jobFactory.pending().build());
+  }
+
+  retryable() {
+    return this.params(jobFactory.retryable().build());
+  }
+
+  running() {
+    return this.params(jobFactory.running().build());
+  }
+
+  scheduled() {
+    return this.params(jobFactory.scheduled().build());
+  }
+
+  scheduledSnoozed() {
+    return this.params(jobFactory.scheduledSnoozed().build());
+  }
+}
+
+export const jobMinimalFactory = JobMinimalFactory.define(({ sequence }) => {
+  const job = jobFactory.build({ id: BigInt(sequence) });
+  return job as JobMinimalFields;
 });
 
 class JobFactory extends Factory<Job, object> {


### PR DESCRIPTION
Issue #347 details how #344 broke some key parts of the frontend due to missing fields in the job list payloads (errors, logs, and metadata were removed from the job payload for the list API). The root issue is that the TypeScript types were not adjusted to reflect the new split Job type, so several parts of the code made reference to things they could no longer access (and didn't actually need anyway). In particular this was true for deserializing job payloads where the same logic was applied to all job responses.

To fix this, update the types to have a separate `JobMinimal` and `Job` type just as the API backend does. Update all code that uses them to ensure the correct one is utilized. It's only list view stuff that needs `JobMinimal` for now.

Fixes #347.