### PR TITLE
switch out tanstack router devtools pkg per warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@tailwindcss/vite": "^4.1.5",
         "@tanstack/eslint-plugin-query": "^5.74.7",
         "@tanstack/react-query-devtools": "^5.75.0",
-        "@tanstack/router-devtools": "^1.119.1",
+        "@tanstack/react-router-devtools": "^1.119.1",
         "@tanstack/router-vite-plugin": "^1.119.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -3299,36 +3299,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/router-devtools": {
-      "version": "1.119.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools/-/router-devtools-1.119.1.tgz",
-      "integrity": "sha512-y6mRyqVANssoIbsBW4uGn1/glmV6nQP7IfyCz7BFFH0D9AnJFr+r014oRl9zFOS2VWY8bXjb05ZTQpcf9oiXFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/react-router-devtools": "^1.119.1",
-        "clsx": "^2.1.1",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-router": "^1.119.0",
-        "csstype": "^3.0.10",
-        "react": ">=18.0.0 || >=19.0.0",
-        "react-dom": ">=18.0.0 || >=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "csstype": {
-          "optional": true
-        }
       }
     },
     "node_modules/@tanstack/router-devtools-core": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@tailwindcss/vite": "^4.1.5",
     "@tanstack/eslint-plugin-query": "^5.74.7",
     "@tanstack/react-query-devtools": "^5.75.0",
-    "@tanstack/router-devtools": "^1.119.1",
+    "@tanstack/react-router-devtools": "^1.119.1",
     "@tanstack/router-vite-plugin": "^1.119.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -7,7 +7,7 @@ const TanStackRouterDevtools =
     ? () => null // Render nothing in production
     : React.lazy(() =>
         // Lazy load in development
-        import("@tanstack/router-devtools").then((res) => ({
+        import("@tanstack/react-router-devtools").then((res) => ({
           default: res.TanStackRouterDevtools,
         })),
       );


### PR DESCRIPTION
This package was renamed per the deprecation warning. This fixes it.