### PR TITLE
Collapsible JSON view

### DIFF
--- a/.cursor/rules/testing-practices.mdc
+++ b/.cursor/rules/testing-practices.mdc
@@ -29,5 +29,5 @@ alwaysApply: false
 - Mock callbacks using `vi.fn()` and clear them between tests using `beforeEach(() => { vi.clearAllMocks(); })`
 
 ## Running Tests
-- Use `npm exec -- vitest --run` to run tests
+- Use `npm run test:once` to run tests with `vitest` cli, optionally with added args like specific filenames.
 - Specify a test file path to run specific tests: `npm exec -- vitest --run src/components/MyComponent.test.tsx`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a flexible search filter UI for the job list. [PR #344](https://github.com/riverqueue/riverui/pull/344).
 - Added `riverlog` middleware logs to the job detail UI via a new unified attempts list, rather than separate lists for errors, attempted by, and now logs. [PR #346](https://github.com/riverqueue/riverui/pull/346).
 
+### Changed
+
+- Job args and metadata on the job detail view now use an interactive collapsible JSON view rather than pretty-printing the entire payload on screen. For large payloads this is a better UX and doesn't disrupt the page flow by default. [PR #351](https://github.com/riverqueue/riverui/pull/351).
+
 ## [v0.9.0] - 2025-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "preview": "LIVE_FS=true reflex -c .reflex.server",
     "storybook": "storybook dev -p 6006",
     "test": "vitest",
+    "test:once": "vitest run",
     "watch:frontend": "vite --open http://localhost:8080/",
     "watch:backend": "LIVE_FS=true DEV=true reflex -c .reflex.server"
   }

--- a/src/components/JSONView.stories.tsx
+++ b/src/components/JSONView.stories.tsx
@@ -229,7 +229,6 @@ export const NestedCollapsedHiddenKeys: Story = {
     copyTitle: "Nested Object (Hidden Keys)",
     data: nestedObject,
     defaultExpandDepth: 0,
-    hideNestedKeys: true,
   },
 };
 

--- a/src/components/JSONView.stories.tsx
+++ b/src/components/JSONView.stories.tsx
@@ -1,0 +1,266 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import JSONView from "./JSONView";
+
+const meta: Meta<typeof JSONView> = {
+  component: JSONView,
+  parameters: {
+    layout: "centered",
+  },
+  title: "Components/JSONView",
+};
+
+export default meta;
+type Story = StoryObj<typeof JSONView>;
+
+// Sample JSON data
+const simpleObject = {
+  age: 30,
+  email: "john@example.com",
+  isActive: true,
+  name: "John Doe",
+};
+
+const nestedObject = {
+  person: {
+    contact: {
+      address: {
+        city: "Anytown",
+        country: "USA",
+        street: "123 Main St",
+      },
+      email: "john@example.com",
+      phone: "555-1234",
+    },
+    name: "John Doe",
+  },
+  preferences: {
+    notifications: true,
+    theme: "dark",
+  },
+  stats: {
+    lastLogin: "2023-09-15T14:30:00Z",
+    loginCount: 42,
+  },
+};
+
+const arrayExample = [
+  "apple",
+  "banana",
+  "cherry",
+  "date",
+  "elderberry",
+  "fig",
+  "grape",
+];
+
+const mixedExample = {
+  emptyArray: [],
+  emptyObject: {},
+  items: [
+    { id: 1, value: "first" },
+    { id: 2, value: "second" },
+    { id: 3, value: "third" },
+  ],
+  metadata: {
+    count: 3,
+    pageSize: 10,
+    timestamp: "2023-09-15T14:30:00Z",
+  },
+  null: null,
+  settings: {
+    config: {
+      retries: 3,
+      timeout: 5000,
+    },
+    isEnabled: true,
+  },
+};
+
+const longStringExample = {
+  longString:
+    "This is a very long string that should definitely wrap to multiple lines in the view. It contains enough text to demonstrate how the component handles long strings and text wrapping behavior.",
+  mediumString: "This is a medium length string that should wrap",
+  shortString: "Hello",
+  url: "https://very-long-domain-name-for-testing-purposes-and-seeing-how-it-wraps.example.com/path/to/resource?param1=value1&param2=value2",
+};
+
+const bigJson = {
+  customer: {
+    accountCreated: "2022-01-15T08:30:00Z",
+    email: "customer@example.com",
+    id: "cus_abcdef123456",
+    name: "Alice Customer",
+    preferences: {
+      language: "en-US",
+      marketing: false,
+      theme: "dark",
+      timezone: "America/Los_Angeles",
+    },
+    subscription: {
+      endDate: null,
+      features: ["feature1", "feature2", "feature3", "feature4", "feature5"],
+      interval: "monthly",
+      plan: "premium",
+      price: 29.99,
+      startDate: "2022-02-01T00:00:00Z",
+      status: "active",
+    },
+  },
+  jobData: {
+    attempts: 1,
+    backoff: { initialInterval: 30, strategy: "exponential" },
+    created: "2023-04-01T12:00:00Z",
+    finished: "2023-04-01T12:00:15Z",
+    id: "j_012345abcdef",
+    kind: "ProcessPaymentJob",
+    maxAttempts: 3,
+    priority: 5,
+    queueName: "payments",
+    started: "2023-04-01T12:00:05Z",
+    status: "completed",
+  },
+  metadata: {
+    applicationVersion: "1.2.3",
+    merchantId: "merch_12345abcde",
+    referrer: "https://example.com/checkout",
+    requestId: "req_zyxwvu987654",
+    sessionId: "sess_abcdef123456",
+    sourceIp: "192.168.1.100",
+    tags: ["payment", "production", "high-value"],
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36",
+  },
+  paymentDetails: {
+    amount: 129.99,
+    cardDetails: {
+      billingAddress: {
+        city: "Finance City",
+        country: "US",
+        postalCode: "12345",
+        state: "FC",
+        street: "123 Payment Street",
+      },
+      expiryMonth: 4,
+      expiryYear: 2025,
+      lastFour: "4242",
+      network: "Visa",
+    },
+    currency: "USD",
+    method: "credit_card",
+    transactionId: "txn_98765zyxwvu",
+  },
+  processingResults: {
+    gatewayResponse: {
+      authorizationCode: "AUTH123456",
+      code: "approved",
+      message: "Payment processed successfully",
+      metadata: {
+        gatewayId: "gateway_12345",
+        processingTime: 1.23,
+        retryCount: 0,
+        route: "primary",
+      },
+      networkCode: "00",
+      riskScore: 15,
+    },
+    logs: [
+      {
+        level: "info",
+        message: "Payment processing started",
+        timestamp: "2023-04-01T12:00:05Z",
+      },
+      {
+        level: "debug",
+        message: "Card validation successful",
+        timestamp: "2023-04-01T12:00:06Z",
+      },
+      {
+        details: {
+          avsMessage: "Address and postal code match",
+          avsResult: "Y",
+        },
+        level: "debug",
+        message: "Address verification completed",
+        timestamp: "2023-04-01T12:00:07Z",
+      },
+      {
+        level: "info",
+        message: "Payment gateway returned success response",
+        timestamp: "2023-04-01T12:00:14Z",
+      },
+      {
+        level: "info",
+        message: "Payment processing completed successfully",
+        timestamp: "2023-04-01T12:00:15Z",
+      },
+    ],
+    success: true,
+    timestamp: "2023-04-01T12:00:14Z",
+  },
+};
+
+export const Simple: Story = {
+  args: {
+    copyTitle: "Simple Object",
+    data: simpleObject,
+    defaultExpandDepth: 5,
+  },
+};
+
+export const Nested: Story = {
+  args: {
+    copyTitle: "Nested Object",
+    data: nestedObject,
+    defaultExpandDepth: 1,
+  },
+};
+
+export const NestedCollapsed: Story = {
+  args: {
+    copyTitle: "Nested Object (All Keys Visible)",
+    data: nestedObject,
+    defaultExpandDepth: 0,
+  },
+};
+
+export const NestedCollapsedHiddenKeys: Story = {
+  args: {
+    copyTitle: "Nested Object (Hidden Keys)",
+    data: nestedObject,
+    defaultExpandDepth: 0,
+    hideNestedKeys: true,
+  },
+};
+
+export const Array: Story = {
+  args: {
+    copyTitle: "Array",
+    data: arrayExample,
+    defaultExpandDepth: 1,
+  },
+};
+
+export const Mixed: Story = {
+  args: {
+    copyTitle: "Mixed Data",
+    data: mixedExample,
+    defaultExpandDepth: 1,
+  },
+};
+
+export const LongStrings: Story = {
+  args: {
+    copyTitle: "Long Strings",
+    data: longStringExample,
+    defaultExpandDepth: 3,
+  },
+};
+
+export const LargeJSON: Story = {
+  args: {
+    copyTitle: "Large JSON",
+    data: bigJson,
+    defaultExpandDepth: 0,
+  },
+};

--- a/src/components/JSONView.test.tsx
+++ b/src/components/JSONView.test.tsx
@@ -1,0 +1,301 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import toast from "react-hot-toast";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import JSONView from "./JSONView";
+
+// Mock clipboard API
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+  },
+});
+
+// Mock toast
+vi.mock("react-hot-toast", () => ({
+  default: {
+    custom: vi.fn(),
+  },
+}));
+
+describe("JSONView Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const simpleData = {
+    age: 30,
+    isActive: true,
+    name: "John Doe",
+  };
+
+  const nestedData = {
+    items: ["apple", "banana", "cherry"],
+    person: {
+      contact: {
+        email: "jane@example.com",
+        phone: "555-5678",
+      },
+      name: "Jane Smith",
+    },
+  };
+
+  it("renders simple JSON data", () => {
+    render(<JSONView data={simpleData} />);
+
+    // Check that key elements are in the document
+    expect(screen.getByTestId("json-view")).toBeInTheDocument();
+    expect(screen.getByText(/"name"/)).toBeInTheDocument();
+    expect(screen.getByText(/"John Doe"/)).toBeInTheDocument();
+    expect(screen.getByText(/"age"/)).toBeInTheDocument();
+    expect(screen.getByText(/30/)).toBeInTheDocument();
+    expect(screen.getByText(/"isActive"/)).toBeInTheDocument();
+    expect(screen.getByText(/true/)).toBeInTheDocument();
+  });
+
+  it("renders nested JSON data with collapsed nodes but visible keys by default", () => {
+    render(<JSONView data={nestedData} defaultExpandDepth={1} />);
+
+    // The root node should be initially expanded since defaultExpandDepth=1
+    expect(screen.getByText(/person/i, { exact: false })).toBeInTheDocument();
+
+    // Find the element containing "items" that's also near ":"
+    const itemsElements = screen.getAllByText(/items/i);
+    const itemsKeyElement = itemsElements.find((el) =>
+      el.nextSibling?.textContent?.includes(":"),
+    );
+    expect(itemsKeyElement).toBeDefined();
+
+    // Child nodes of person should be visible when expanded
+    const personButton = screen
+      .getAllByRole("button")
+      .find((button) => button.textContent?.includes("person"));
+
+    expect(personButton).toBeDefined();
+    if (personButton) {
+      fireEvent.click(personButton);
+
+      // Now the name should be visible
+      expect(screen.getByText(/Jane Smith/i)).toBeInTheDocument();
+      expect(screen.getByText(/contact/i)).toBeInTheDocument();
+    }
+  });
+
+  it("renders nested JSON data with all nodes collapsed when defaultExpandDepth is 0", () => {
+    render(<JSONView data={nestedData} defaultExpandDepth={0} />);
+
+    // When defaultExpandDepth is 0, the root disclosure button should be collapsed
+    // We should see the text indicating how many keys, but not the keys themselves
+    expect(screen.getByText(/keys/i)).toBeInTheDocument();
+
+    // Keys of children within the collapsed root should not be visible
+    expect(screen.queryByText(/person/i)).toBeNull();
+    expect(screen.queryByText(/items/i)).toBeNull();
+  });
+
+  it("expands and collapses nodes when clicked (starting with defaultExpandDepth 0)", async () => {
+    render(<JSONView data={nestedData} defaultExpandDepth={0} />);
+
+    // Initial state: root is collapsed
+    expect(screen.queryByText(/person/i)).toBeNull();
+    expect(screen.queryByText(/items/i)).toBeNull();
+
+    // Find disclosure button for the root
+    const rootButton = screen
+      .getAllByRole("button")
+      .find((el) => el.textContent?.includes("{"));
+
+    expect(rootButton).toBeDefined();
+    if (rootButton) {
+      fireEvent.click(rootButton);
+
+      // Now the first level keys should be visible
+      await waitFor(() => {
+        expect(
+          screen.getByText(/person/i, { exact: false }),
+        ).toBeInTheDocument();
+
+        // Check for "items" key with a more specific approach - find elements with "items"
+        // and filter to find the one that has ":" as a sibling
+        const itemsElements = screen.getAllByText(/items/i);
+        const itemsKeyElement = itemsElements.find((el) =>
+          el.nextSibling?.textContent?.includes(":"),
+        );
+        expect(itemsKeyElement).toBeDefined();
+      });
+
+      // But second level should still be collapsed
+      expect(screen.queryByText(/Jane Smith/i)).toBeNull();
+
+      // Get the disclosure button for the person object
+      const personButton = screen
+        .getAllByRole("button")
+        .find((button) => button.textContent?.includes("person"));
+
+      expect(personButton).toBeDefined();
+      if (personButton) {
+        fireEvent.click(personButton);
+
+        // Now the person details should be visible
+        await waitFor(() => {
+          expect(screen.getByText(/name/i)).toBeInTheDocument();
+          expect(screen.getByText(/Jane Smith/i)).toBeInTheDocument();
+        });
+      }
+
+      // Click to collapse the root node
+      fireEvent.click(rootButton);
+
+      // First level keys should now be hidden
+      await waitFor(() => {
+        expect(screen.queryByText(/person/i)).toBeNull();
+        expect(screen.queryByText(/items/i)).toBeNull();
+      });
+    }
+  });
+
+  it("copies JSON to clipboard when the copy button is clicked", async () => {
+    render(<JSONView copyTitle="Test Data" data={simpleData} />);
+
+    // Find and click the copy button
+    const copyButton = screen.getByTestId("json-copy-button");
+
+    // Wrap in act because it causes state updates
+    await act(async () => {
+      fireEvent.click(copyButton);
+    });
+
+    // Verify clipboard API was called with the correct data
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      JSON.stringify(simpleData, null, 2),
+    );
+
+    // We need to wait for the state update and toast call
+    await waitFor(() => {
+      expect(toast.custom).toHaveBeenCalled();
+    });
+  });
+
+  it("renders null and undefined values", () => {
+    const data = {
+      nullValue: null,
+      undefinedValue: undefined,
+    };
+
+    render(<JSONView data={data} />);
+
+    expect(screen.getByText(/nullValue/i)).toBeInTheDocument();
+    expect(screen.getByTestId("json-null")).toBeInTheDocument();
+    expect(screen.getByText(/undefinedValue/i)).toBeInTheDocument();
+    expect(screen.getByTestId("json-undefined")).toBeInTheDocument();
+  });
+
+  it("expands nested objects in default mode when clicking value toggles", async () => {
+    render(<JSONView data={nestedData} defaultExpandDepth={1} />);
+
+    // Expand the "person" object
+    const personButton = screen
+      .getAllByRole("button")
+      .find((button) => button.textContent?.includes("person"));
+
+    expect(personButton).toBeDefined();
+    if (personButton) {
+      fireEvent.click(personButton);
+
+      // Now find and click the contact toggle to expand it
+      await waitFor(() => {
+        const contactButton = screen
+          .getAllByRole("button")
+          .find((button) => button.textContent?.includes("contact"));
+        expect(contactButton).toBeDefined();
+        if (contactButton) {
+          fireEvent.click(contactButton);
+        }
+      });
+
+      // Now the content inside the contact object should be visible
+      await waitFor(() => {
+        expect(screen.getByText(/email/i)).toBeInTheDocument();
+        expect(screen.getByText(/jane@example.com/i)).toBeInTheDocument();
+        expect(screen.getByText(/phone/i)).toBeInTheDocument();
+      });
+    }
+  });
+
+  it("expands objects within an array to their first level when the array is expanded", async () => {
+    const arrayWithNestedObjects = {
+      list: [
+        {
+          details: {
+            type: "A",
+            value: 100,
+          },
+          id: 1,
+          name: "Item One",
+        },
+        {
+          details: {
+            type: "B",
+            value: 200,
+          },
+          id: 2,
+          name: "Item Two",
+        },
+      ],
+    };
+
+    render(<JSONView data={arrayWithNestedObjects} defaultExpandDepth={0} />);
+
+    // Initially, everything is collapsed with defaultExpandDepth=0
+    expect(screen.getByText(/key/i)).toBeInTheDocument();
+
+    // Expand the root first
+    const rootButton = screen
+      .getAllByRole("button")
+      .find((button) => button.textContent?.includes("{"));
+
+    expect(rootButton).toBeDefined();
+    if (rootButton) {
+      fireEvent.click(rootButton);
+
+      // Now we should see the "list" key
+      await waitFor(() => {
+        expect(screen.getByText(/list/i)).toBeInTheDocument();
+      });
+
+      // Expand the list array
+      const listButton = screen
+        .getAllByRole("button")
+        .find((button) => button.textContent?.includes("list"));
+
+      expect(listButton).toBeDefined();
+      if (listButton) {
+        fireEvent.click(listButton);
+
+        // After expanding "list", all objects within the array should be expanded to first level
+        await waitFor(() => {
+          // Check for properties in the array items
+          expect(screen.getAllByText(/id/i).length).toBeGreaterThan(0);
+          expect(screen.getAllByText(/name/i).length).toBeGreaterThan(0);
+          expect(screen.getAllByText(/details/i).length).toBeGreaterThan(0);
+
+          // Check for specific values
+          expect(screen.getByText(/Item One/i)).toBeInTheDocument();
+          expect(screen.getByText(/Item Two/i)).toBeInTheDocument();
+        });
+
+        // Now, let's test collapsing the array again
+        fireEvent.click(listButton);
+        await waitFor(() => {
+          expect(screen.queryByText(/Item One/i)).toBeNull();
+        });
+      }
+    }
+  });
+});

--- a/src/components/JSONView.test.tsx
+++ b/src/components/JSONView.test.tsx
@@ -50,7 +50,6 @@ describe("JSONView Component", () => {
     render(<JSONView data={simpleData} />);
 
     // Check that key elements are in the document
-    expect(screen.getByTestId("json-view")).toBeInTheDocument();
     expect(screen.getByText(/"name"/)).toBeInTheDocument();
     expect(screen.getByText(/"John Doe"/)).toBeInTheDocument();
     expect(screen.getByText(/"age"/)).toBeInTheDocument();
@@ -164,7 +163,7 @@ describe("JSONView Component", () => {
     render(<JSONView copyTitle="Test Data" data={simpleData} />);
 
     // Find and click the copy button
-    const copyButton = screen.getByTestId("json-copy-button");
+    const copyButton = screen.getByTestId("text-copy-button");
 
     // Wrap in act because it causes state updates
     await act(async () => {
@@ -172,9 +171,16 @@ describe("JSONView Component", () => {
     });
 
     // Verify clipboard API was called with the correct data
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      JSON.stringify(simpleData, null, 2),
-    );
+    // The content might be formatted differently, so we'll check if it contains the data
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    const clipboardCall = (
+      navigator.clipboard.writeText as unknown as {
+        mock: { calls: string[][] };
+      }
+    ).mock.calls[0][0];
+    expect(clipboardCall).toContain('"age": 30');
+    expect(clipboardCall).toContain('"isActive": true');
+    expect(clipboardCall).toContain('"name": "John Doe"');
 
     // We need to wait for the state update and toast call
     await waitFor(() => {

--- a/src/components/JSONView.tsx
+++ b/src/components/JSONView.tsx
@@ -1,18 +1,11 @@
-import { ToastContentSuccess } from "@/components/Toast";
+import PlaintextPanel from "@/components/PlaintextPanel";
 import {
   Disclosure,
   DisclosureButton,
   DisclosurePanel,
 } from "@headlessui/react";
-import { CheckIcon } from "@heroicons/react/16/solid";
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  ClipboardIcon,
-} from "@heroicons/react/24/outline";
-import { useState } from "react";
+import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import React from "react";
-import toast from "react-hot-toast";
 
 interface JSONNodeRendererProps {
   data: unknown;
@@ -24,6 +17,10 @@ interface JSONNodeRendererProps {
 }
 
 interface JSONViewProps {
+  /**
+   * Additional class names to apply to the component.
+   */
+  className?: string;
   /**
    * The title to show in the copy confirmation toast.
    * @default "JSON"
@@ -41,154 +38,32 @@ interface JSONViewProps {
  * A component that renders JSON data with collapsible sections and a copy button.
  */
 export default function JSONView({
+  className,
   copyTitle = "JSON",
   data,
   defaultExpandDepth = 1,
 }: JSONViewProps) {
-  const [isCopied, setIsCopied] = useState(false);
-
-  const copyToClipboard = () => {
-    const jsonString = JSON.stringify(data, null, 2);
-    navigator.clipboard.writeText(jsonString).then(
-      () => {
-        setIsCopied(true);
-        toast.custom((t) => (
-          <ToastContentSuccess
-            message={`${copyTitle} copied to clipboard`}
-            t={t}
-          />
-        ));
-        setTimeout(() => {
-          setIsCopied(false);
-        }, 2000);
-      },
-      (err) => {
-        console.error("Failed to copy JSON: ", err);
-      },
-    );
-  };
-
-  const styleConfig = {
-    container: {
-      base: "relative overflow-auto rounded-md bg-slate-50 dark:bg-slate-800",
-      font: { fontFamily: "var(--font-family-monospace, monospace)" },
-    },
-    content: {
-      base: "relative text-xs",
-      code: "block text-slate-800 dark:text-slate-200",
-      layout: {
-        overflowX: "auto" as const,
-        overscrollBehaviorY: "auto" as const,
-        paddingBottom: "4px",
-        paddingLeft: "24px",
-        paddingTop: "4px",
-      },
-    },
-    header: {
-      base: "flex items-center justify-end bg-slate-100 px-2 py-1 text-xs dark:bg-slate-700",
-      textAlign: { textAlign: "right" as const },
-    },
-    icon: {
-      base: "h-3 w-3",
-      check: "text-green-500",
-      chevron: "text-slate-600 dark:text-slate-400",
-      clipboard:
-        "text-slate-500 dark:text-slate-400 hover:text-brand-primary dark:hover:text-brand-primary",
-    },
-    json: {
-      button: {
-        alignItems: "baseline",
-        cursor: "pointer",
-        display: "flex",
-        padding: "2px 0",
-        position: "relative",
-      },
-      chevron: {
-        left: "-16px",
-        lineHeight: 1,
-        position: "absolute",
-        top: "0.35em",
-      },
-      item: {
-        paddingBottom: "2px",
-        paddingTop: "2px",
-        position: "relative",
-      },
-      key: "text-slate-600 dark:text-slate-400",
-      node: {
-        alignItems: "flex-start",
-        display: "flex",
-        flexDirection: "column",
-        position: "relative",
-      },
-      panel: {
-        marginLeft: "1.5em",
-        paddingTop: "2px",
-        width: "100%",
-      },
-      summary: {
-        base: "text-slate-600 dark:text-slate-400",
-        style: { fontStyle: "italic", margin: "0 4px" },
-      },
-      value: {
-        boolean: "text-red-600 dark:text-red-400",
-        default: "text-slate-800 dark:text-slate-200",
-        null: "text-red-600 dark:text-red-400",
-        number: "text-amber-600 dark:text-amber-400",
-        string: "text-green-600 dark:text-green-400",
-      },
-    },
-  };
+  const jsonContent = (
+    <>
+      <JSONNodeRenderer
+        data={data}
+        defaultExpandDepth={defaultExpandDepth}
+        depth={0}
+        isLastItemInParent={true}
+        isParentArrayItem={false}
+        propKey={null}
+      />
+    </>
+  );
 
   return (
-    <div
-      className={styleConfig.container.base}
-      data-testid="json-view"
-      style={styleConfig.container.font}
-    >
-      {/* Header with copy button */}
-      <div
-        className={styleConfig.header.base}
-        style={styleConfig.header.textAlign}
-      >
-        <button
-          className="inline-flex cursor-pointer items-center rounded p-1"
-          data-testid="json-copy-button"
-          onClick={copyToClipboard}
-          tabIndex={0}
-          title="Copy to clipboard"
-          type="button"
-        >
-          {isCopied ? (
-            <CheckIcon
-              aria-hidden="true"
-              className={`${styleConfig.icon.base} ${styleConfig.icon.check}`}
-            />
-          ) : (
-            <ClipboardIcon
-              aria-hidden="true"
-              className={`${styleConfig.icon.base} ${styleConfig.icon.clipboard}`}
-            />
-          )}
-        </button>
-      </div>
-      {/* JSON code block */}
-      <div
-        className={styleConfig.content.base}
-        style={styleConfig.content.layout}
-      >
-        <code className={styleConfig.content.code}>
-          <JSONNodeRenderer
-            data={data}
-            defaultExpandDepth={defaultExpandDepth}
-            depth={0}
-            isLastItemInParent={true}
-            isParentArrayItem={false}
-            propKey={null}
-          />
-        </code>
-      </div>
-    </div>
+    <PlaintextPanel
+      className={className}
+      codeClassName="pl-6"
+      content={jsonContent}
+      copyTitle={copyTitle}
+      rawText={JSON.stringify(data, null, 2)}
+    />
   );
 }
 

--- a/src/components/JSONView.tsx
+++ b/src/components/JSONView.tsx
@@ -1,0 +1,696 @@
+import { ToastContentSuccess } from "@/components/Toast";
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from "@headlessui/react";
+import { CheckIcon } from "@heroicons/react/16/solid";
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ClipboardIcon,
+} from "@heroicons/react/24/outline";
+import { useState } from "react";
+import React from "react";
+import toast from "react-hot-toast";
+
+interface JSONNodeRendererProps {
+  data: unknown;
+  defaultExpandDepth: number;
+  depth: number;
+  isLastItemInParent: boolean;
+  isParentArrayItem?: boolean; // True if the direct parent of this node is an array
+  propKey: null | string; // Key if this node is a property of an object
+}
+
+interface JSONViewProps {
+  /**
+   * The title to show in the copy confirmation toast.
+   * @default "JSON"
+   */
+  copyTitle?: string;
+  data: unknown;
+  /**
+   * The maximum depth to automatically expand to.
+   * @default 1
+   */
+  defaultExpandDepth?: number;
+}
+
+/**
+ * A component that renders JSON data with collapsible sections and a copy button.
+ */
+export default function JSONView({
+  copyTitle = "JSON",
+  data,
+  defaultExpandDepth = 1,
+}: JSONViewProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copyToClipboard = () => {
+    const jsonString = JSON.stringify(data, null, 2);
+    navigator.clipboard.writeText(jsonString).then(
+      () => {
+        setIsCopied(true);
+        toast.custom((t) => (
+          <ToastContentSuccess
+            message={`${copyTitle} copied to clipboard`}
+            t={t}
+          />
+        ));
+        setTimeout(() => {
+          setIsCopied(false);
+        }, 2000);
+      },
+      (err) => {
+        console.error("Failed to copy JSON: ", err);
+      },
+    );
+  };
+
+  const styleConfig = {
+    container: {
+      base: "relative overflow-auto rounded-md bg-slate-50 dark:bg-slate-800",
+      font: { fontFamily: "var(--font-family-monospace, monospace)" },
+    },
+    content: {
+      base: "relative text-xs",
+      code: "block text-slate-800 dark:text-slate-200",
+      layout: {
+        overflowX: "auto" as const,
+        overscrollBehaviorY: "auto" as const,
+        paddingBottom: "4px",
+        paddingLeft: "24px",
+        paddingTop: "4px",
+      },
+    },
+    header: {
+      base: "flex items-center justify-end bg-slate-100 px-2 py-1 text-xs dark:bg-slate-700",
+      textAlign: { textAlign: "right" as const },
+    },
+    icon: {
+      base: "h-3 w-3",
+      check: "text-green-500",
+      chevron: "text-slate-600 dark:text-slate-400",
+      clipboard:
+        "text-slate-500 dark:text-slate-400 hover:text-brand-primary dark:hover:text-brand-primary",
+    },
+    json: {
+      button: {
+        alignItems: "baseline",
+        cursor: "pointer",
+        display: "flex",
+        padding: "2px 0",
+        position: "relative",
+      },
+      chevron: {
+        left: "-16px",
+        lineHeight: 1,
+        position: "absolute",
+        top: "0.35em",
+      },
+      item: {
+        paddingBottom: "2px",
+        paddingTop: "2px",
+        position: "relative",
+      },
+      key: "text-slate-600 dark:text-slate-400",
+      node: {
+        alignItems: "flex-start",
+        display: "flex",
+        flexDirection: "column",
+        position: "relative",
+      },
+      panel: {
+        marginLeft: "1.5em",
+        paddingTop: "2px",
+        width: "100%",
+      },
+      summary: {
+        base: "text-slate-600 dark:text-slate-400",
+        style: { fontStyle: "italic", margin: "0 4px" },
+      },
+      value: {
+        boolean: "text-red-600 dark:text-red-400",
+        default: "text-slate-800 dark:text-slate-200",
+        null: "text-red-600 dark:text-red-400",
+        number: "text-amber-600 dark:text-amber-400",
+        string: "text-green-600 dark:text-green-400",
+      },
+    },
+  };
+
+  return (
+    <div
+      className={styleConfig.container.base}
+      data-testid="json-view"
+      style={styleConfig.container.font}
+    >
+      {/* Header with copy button */}
+      <div
+        className={styleConfig.header.base}
+        style={styleConfig.header.textAlign}
+      >
+        <button
+          className="inline-flex cursor-pointer items-center rounded p-1"
+          data-testid="json-copy-button"
+          onClick={copyToClipboard}
+          tabIndex={0}
+          title="Copy to clipboard"
+          type="button"
+        >
+          {isCopied ? (
+            <CheckIcon
+              aria-hidden="true"
+              className={`${styleConfig.icon.base} ${styleConfig.icon.check}`}
+            />
+          ) : (
+            <ClipboardIcon
+              aria-hidden="true"
+              className={`${styleConfig.icon.base} ${styleConfig.icon.clipboard}`}
+            />
+          )}
+        </button>
+      </div>
+      {/* JSON code block */}
+      <div
+        className={styleConfig.content.base}
+        style={styleConfig.content.layout}
+      >
+        <code className={styleConfig.content.code}>
+          <JSONNodeRenderer
+            data={data}
+            defaultExpandDepth={defaultExpandDepth}
+            depth={0}
+            isLastItemInParent={true}
+            isParentArrayItem={false}
+            propKey={null}
+          />
+        </code>
+      </div>
+    </div>
+  );
+}
+
+function JSONNodeRenderer({
+  data,
+  defaultExpandDepth,
+  depth,
+  isLastItemInParent,
+  isParentArrayItem = false,
+  propKey,
+}: JSONNodeRendererProps) {
+  const styleConfig = {
+    container: {
+      base: "relative overflow-auto rounded-md bg-slate-50 dark:bg-slate-800",
+      font: { fontFamily: "var(--font-family-monospace, monospace)" },
+    },
+    content: {
+      base: "relative text-xs",
+      code: "block text-slate-800 dark:text-slate-200",
+      layout: {
+        overflowX: "auto" as const,
+        overscrollBehaviorY: "auto" as const,
+        paddingBottom: "4px",
+        paddingLeft: "24px",
+        paddingTop: "4px",
+      },
+    },
+    header: {
+      base: "flex items-center justify-end bg-slate-100 px-2 py-1 text-xs dark:bg-slate-700",
+      textAlign: { textAlign: "right" as const },
+    },
+    icon: {
+      base: "h-3 w-3",
+      check: "text-green-500",
+      chevron: "text-slate-600 dark:text-slate-400",
+      clipboard:
+        "text-slate-500 dark:text-slate-400 hover:text-brand-primary dark:hover:text-brand-primary",
+    },
+    json: {
+      button: {
+        alignItems: "baseline",
+        cursor: "pointer",
+        display: "flex",
+        padding: "2px 0",
+        position: "relative",
+      },
+      chevron: {
+        left: "-16px",
+        lineHeight: 1,
+        position: "absolute",
+        top: "0.35em",
+      },
+      item: {
+        paddingBottom: "2px",
+        paddingTop: "2px",
+        position: "relative",
+      },
+      key: "text-slate-600 dark:text-slate-400",
+      node: {
+        alignItems: "flex-start",
+        display: "flex",
+        flexDirection: "column",
+        position: "relative",
+      },
+      panel: {
+        marginLeft: "1.5em",
+        paddingTop: "2px",
+        width: "100%",
+      },
+      summary: {
+        base: "text-slate-600 dark:text-slate-400",
+        style: { fontStyle: "italic", margin: "0 4px" },
+      },
+      value: {
+        boolean: "text-red-600 dark:text-red-400",
+        default: "text-slate-800 dark:text-slate-200",
+        null: "text-red-600 dark:text-red-400",
+        number: "text-amber-600 dark:text-amber-400",
+        string: "text-green-600 dark:text-green-400",
+      },
+    },
+  };
+
+  const valueColor = (type: string) => {
+    if (type === "string") return styleConfig.json.value.string;
+    if (type === "number") return styleConfig.json.value.number;
+    if (type === "boolean") return styleConfig.json.value.boolean;
+    if (type === "null") return styleConfig.json.value.null;
+    return styleConfig.json.value.default;
+  };
+  const color = styleConfig.json.key;
+
+  // For primitive values, render key and value inline
+  if (propKey && (typeof data !== "object" || data === null)) {
+    return (
+      <span
+        style={{
+          alignItems: "baseline",
+          display: "flex",
+          flexDirection: "row",
+          whiteSpace: "nowrap",
+        }}
+      >
+        <span className={styleConfig.json.key}>&quot;{propKey}&quot;</span>
+        <span className={styleConfig.json.key}>:&nbsp;</span>
+        {typeof data === "string" ? (
+          <span className={valueColor("string")} style={{ whiteSpace: "pre" }}>
+            {JSON.stringify(data)}
+            {maybeComma(isLastItemInParent)}
+          </span>
+        ) : (
+          renderValue(
+            data,
+            valueColor,
+            isLastItemInParent,
+            depth,
+            defaultExpandDepth,
+            isParentArrayItem,
+          )
+        )}
+      </span>
+    );
+  }
+
+  // For non-primitive values (objects/arrays) or non-property values, use the normal rendering
+  if (!propKey) {
+    return renderValue(
+      data,
+      valueColor,
+      isLastItemInParent,
+      depth,
+      defaultExpandDepth,
+      isParentArrayItem,
+    );
+  }
+
+  // For objects/arrays that are property values, render the key inline with the value
+  const isArray = Array.isArray(data);
+  const entries = isArray
+    ? data
+    : Object.entries(data as Record<string, unknown>);
+  const count = entries.length;
+
+  if (count === 0) {
+    return (
+      <span>
+        <span style={{ color }}>&quot;{propKey}&quot;</span>
+        <span style={{ color }}>:&nbsp;</span>
+        <span>
+          {isArray ? "[]" : "{}"}
+          {maybeComma(isLastItemInParent)}
+        </span>
+      </span>
+    );
+  }
+
+  const effectiveDefaultOpen =
+    isParentArrayItem && typeof data === "object" && !Array.isArray(data)
+      ? true
+      : depth < defaultExpandDepth;
+
+  return (
+    <Disclosure defaultOpen={effectiveDefaultOpen}>
+      {({ open }) => (
+        <div
+          style={{
+            alignItems: "flex-start",
+            display: "flex",
+            flexDirection: "column",
+            position: "relative",
+          }}
+        >
+          <DisclosureButton
+            as="div"
+            role="button"
+            style={{
+              alignItems: "baseline",
+              cursor: "pointer",
+              display: "flex",
+              padding: "2px 0",
+              position: "relative",
+            }}
+          >
+            <span
+              className="text-slate-600 dark:text-slate-400"
+              style={{
+                left: "-16px",
+                lineHeight: 1,
+                position: "absolute",
+                top: "0.35em",
+              }}
+            >
+              {open ? (
+                <ChevronDownIcon
+                  className="inline-block"
+                  height={8}
+                  width={8}
+                />
+              ) : (
+                <ChevronRightIcon
+                  className="inline-block"
+                  height={8}
+                  width={8}
+                />
+              )}
+            </span>
+            <span style={{ color }}>&quot;{propKey}&quot;</span>
+            <span style={{ color }}>:&nbsp;</span>
+            <span>{isArray ? "[" : "{"}</span>
+            {!open && (
+              <>
+                <span
+                  className="text-slate-600 dark:text-slate-400"
+                  style={{
+                    fontStyle: "italic",
+                    margin: "0 4px",
+                  }}
+                >
+                  … {count} {isArray ? "item" : "key"}
+                  {count !== 1 ? "s" : ""}
+                </span>
+                <span>
+                  {isArray ? "]" : "}"}
+                  {maybeComma(isLastItemInParent)}
+                </span>
+              </>
+            )}
+          </DisclosureButton>
+
+          {open && (
+            <>
+              <DisclosurePanel
+                as="div"
+                static
+                style={{
+                  marginLeft: "1.5em",
+                  paddingTop: "2px",
+                  width: "100%",
+                }}
+              >
+                {isArray
+                  ? (data as unknown[]).map((item, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          paddingBottom: "2px",
+                          paddingTop: "2px",
+                          position: "relative",
+                        }}
+                      >
+                        <JSONNodeRenderer
+                          data={item}
+                          defaultExpandDepth={defaultExpandDepth}
+                          depth={depth + 1}
+                          isLastItemInParent={i === count - 1}
+                          isParentArrayItem={true}
+                          propKey={null}
+                        />
+                      </div>
+                    ))
+                  : (entries as [string, unknown][]).map(([key, value], i) => (
+                      <div
+                        key={key}
+                        style={{
+                          paddingBottom: "2px",
+                          paddingTop: "2px",
+                          position: "relative",
+                        }}
+                      >
+                        <JSONNodeRenderer
+                          data={value}
+                          defaultExpandDepth={
+                            isParentArrayItem &&
+                            typeof data === "object" &&
+                            !Array.isArray(data)
+                              ? depth + 1
+                              : defaultExpandDepth
+                          }
+                          depth={depth + 1}
+                          isLastItemInParent={i === count - 1}
+                          isParentArrayItem={false}
+                          propKey={key}
+                        />
+                      </div>
+                    ))}
+              </DisclosurePanel>
+              <div style={{ paddingBottom: "2px", paddingTop: "2px" }}>
+                <span>
+                  {isArray ? "]" : "}"}
+                  {maybeComma(isLastItemInParent)}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </Disclosure>
+  );
+}
+
+function maybeComma(isLast: boolean) {
+  return isLast ? null : (
+    <span style={{ color: "var(--color-text-secondary, #6b7280)" }}>,</span>
+  );
+}
+
+function renderValue(
+  data: unknown,
+  valueColor: (type: string) => string,
+  isLastItemInParent: boolean,
+  depth: number,
+  defaultExpandDepth: number,
+  isParentArrayItem?: boolean,
+): React.ReactElement {
+  if (data === null) {
+    return (
+      <span className={valueColor("null")} data-testid="json-null">
+        null{maybeComma(isLastItemInParent)}
+      </span>
+    );
+  }
+  if (data === undefined) {
+    return (
+      <span className={valueColor("null")} data-testid="json-undefined">
+        undefined{maybeComma(isLastItemInParent)}
+      </span>
+    );
+  }
+  if (typeof data === "string") {
+    return (
+      <span className={valueColor("string")} style={{ whiteSpace: "pre" }}>
+        {JSON.stringify(data)}
+        {maybeComma(isLastItemInParent)}
+      </span>
+    );
+  }
+  if (typeof data === "number") {
+    return (
+      <span className={valueColor("number")} data-testid="json-number">
+        {data}
+        {maybeComma(isLastItemInParent)}
+      </span>
+    );
+  }
+  if (typeof data === "boolean") {
+    return (
+      <span className={valueColor("boolean")} data-testid="json-boolean">
+        {String(data)}
+        {maybeComma(isLastItemInParent)}
+      </span>
+    );
+  }
+
+  const isArray = Array.isArray(data);
+  const entries = isArray
+    ? data
+    : Object.entries(data as Record<string, unknown>);
+  const count = entries.length;
+
+  if (count === 0) {
+    return (
+      <span>
+        {isArray ? "[]" : "{}"}
+        {maybeComma(isLastItemInParent)}
+      </span>
+    );
+  }
+
+  const effectiveDefaultOpen =
+    isParentArrayItem && typeof data === "object" && !Array.isArray(data)
+      ? true
+      : depth < defaultExpandDepth;
+
+  return (
+    <Disclosure defaultOpen={effectiveDefaultOpen}>
+      {({ open }) => (
+        <div
+          style={{
+            alignItems: "flex-start",
+            display: "flex",
+            flexDirection: "column",
+            position: "relative",
+          }}
+        >
+          <DisclosureButton
+            as="div"
+            role="button"
+            style={{
+              alignItems: "baseline",
+              cursor: "pointer",
+              display: "flex",
+              padding: "2px 0",
+              position: "relative",
+            }}
+          >
+            <span
+              className="text-slate-600 dark:text-slate-400"
+              style={{
+                left: "-16px",
+                lineHeight: 1,
+                position: "absolute",
+                top: "0.35em",
+              }}
+            >
+              {open ? (
+                <ChevronDownIcon
+                  className="inline-block"
+                  height={8}
+                  width={8}
+                />
+              ) : (
+                <ChevronRightIcon
+                  className="inline-block"
+                  height={8}
+                  width={8}
+                />
+              )}
+            </span>
+            <span>{isArray ? "[" : "{"}</span>
+            {!open && (
+              <>
+                <span
+                  className="text-slate-600 dark:text-slate-400"
+                  style={{
+                    fontStyle: "italic",
+                    margin: "0 4px",
+                  }}
+                >
+                  … {count} {isArray ? "item" : "key"}
+                  {count !== 1 ? "s" : ""}
+                </span>
+                <span>{isArray ? "]" : "}"}</span>
+                {maybeComma(isLastItemInParent)}
+              </>
+            )}
+          </DisclosureButton>
+
+          {open && (
+            <>
+              <DisclosurePanel
+                as="div"
+                static
+                style={{
+                  marginLeft: "1.5em",
+                  paddingTop: "2px",
+                  width: "100%",
+                }}
+              >
+                {isArray
+                  ? (data as unknown[]).map((item, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          paddingBottom: "2px",
+                          paddingTop: "2px",
+                          position: "relative",
+                        }}
+                      >
+                        <JSONNodeRenderer
+                          data={item}
+                          defaultExpandDepth={defaultExpandDepth}
+                          depth={depth + 1}
+                          isLastItemInParent={i === count - 1}
+                          isParentArrayItem={true}
+                          propKey={null}
+                        />
+                      </div>
+                    ))
+                  : (entries as [string, unknown][]).map(([key, value], i) => (
+                      <div
+                        key={key}
+                        style={{
+                          paddingBottom: "2px",
+                          paddingTop: "2px",
+                          position: "relative",
+                        }}
+                      >
+                        <JSONNodeRenderer
+                          data={value}
+                          defaultExpandDepth={
+                            isParentArrayItem &&
+                            typeof data === "object" &&
+                            !Array.isArray(data)
+                              ? depth + 1
+                              : defaultExpandDepth
+                          }
+                          depth={depth + 1}
+                          isLastItemInParent={i === count - 1}
+                          isParentArrayItem={false}
+                          propKey={key}
+                        />
+                      </div>
+                    ))}
+              </DisclosurePanel>
+              <div style={{ paddingBottom: "2px", paddingTop: "2px" }}>
+                <span>{isArray ? "]" : "}"}</span>
+                {maybeComma(isLastItemInParent)}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </Disclosure>
+  );
+}

--- a/src/components/JobAttempts.tsx
+++ b/src/components/JobAttempts.tsx
@@ -1,3 +1,4 @@
+import PlaintextPanel from "@/components/PlaintextPanel";
 import {
   ArrowPathRoundedSquareIcon,
   CheckCircleIcon,
@@ -362,12 +363,11 @@ function AttemptRow({ attemptInfo }: { attemptInfo: AttemptInfo }) {
               </summary>
               <div className="mt-2 space-y-2">
                 {attemptInfo.logs.map((log, idx) => (
-                  <div
-                    className="max-h-[300px] w-full resize-y overflow-x-auto rounded-md bg-slate-300/20 px-4 py-2 font-mono text-sm whitespace-pre text-slate-900 dark:bg-slate-700/20 dark:text-slate-100"
+                  <PlaintextPanel
+                    content={log.log}
+                    copyTitle="Log Entry"
                     key={idx}
-                  >
-                    {log.log}
-                  </div>
+                  />
                 ))}
               </div>
             </details>

--- a/src/components/JobDetail.tsx
+++ b/src/components/JobDetail.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@components/Badge";
 import ButtonForGroup from "@components/ButtonForGroup";
 import JobAttempts from "@components/JobAttempts";
 import JobTimeline from "@components/JobTimeline";
+import JSONView from "@components/JSONView";
 import RelativeTimeFormatter from "@components/RelativeTimeFormatter";
 import TopNavTitleOnly from "@components/TopNavTitleOnly";
 import {
@@ -162,9 +163,7 @@ export default function JobDetail({
                   Args
                 </dt>
                 <dd className="mt-1 text-sm leading-6 text-slate-700 sm:mt-2 dark:text-slate-300">
-                  <pre className="overflow-scroll bg-slate-300/10 p-4 font-mono text-slate-900 dark:bg-slate-700/10 dark:text-slate-100">
-                    {JSON.stringify(job.args, null, 2)}
-                  </pre>
+                  <JSONView copyTitle="Args" data={job.args} />
                 </dd>
               </div>
               <div className="col-span-1 border-t border-slate-100 px-4 py-6 sm:px-0 dark:border-slate-800">
@@ -172,9 +171,7 @@ export default function JobDetail({
                   Metadata
                 </dt>
                 <dd className="mt-1 text-sm leading-6 text-slate-700 sm:mt-2 dark:text-slate-300">
-                  <pre className="overflow-scroll bg-slate-300/10 p-4 font-mono text-slate-900 dark:bg-slate-700/10 dark:text-slate-100">
-                    {JSON.stringify(job.metadata, null, 2)}
-                  </pre>
+                  <JSONView copyTitle="Metadata" data={job.metadata} />
                 </dd>
               </div>
 

--- a/src/components/PlaintextPanel.tsx
+++ b/src/components/PlaintextPanel.tsx
@@ -1,0 +1,144 @@
+import { ToastContentSuccess } from "@/components/Toast";
+import { CheckIcon } from "@heroicons/react/16/solid";
+import { ClipboardIcon } from "@heroicons/react/24/outline";
+import { useState } from "react";
+import React from "react";
+import toast from "react-hot-toast";
+
+type PlaintextPanelProps = {
+  /**
+   * Additional class names to apply to the component.
+   */
+  className?: string;
+  /**
+   * Additional class names to apply to the code element.
+   */
+  codeClassName?: string;
+  /**
+   * The content to be displayed in the panel.
+   */
+  content: React.ReactNode;
+  /**
+   * The title to show in the copy confirmation toast.
+   * @default "Text"
+   */
+  copyTitle?: string;
+  /**
+   * Raw text to be copied to clipboard instead of extracting from content.
+   */
+  rawText?: string;
+};
+
+const styleConfig = {
+  container: {
+    base: "relative overflow-auto rounded-md bg-slate-50 dark:bg-slate-800",
+    font: { fontFamily: "var(--font-family-monospace, monospace)" },
+  },
+  content: {
+    base: "relative text-xs p-1 pl-2",
+    code: "block text-slate-800 dark:text-slate-200",
+    layout: {
+      overflowX: "auto" as const,
+      overscrollBehaviorY: "auto" as const,
+    },
+  },
+  header: {
+    base: "flex items-center justify-end bg-slate-100 px-2 py-1 text-xs dark:bg-slate-700",
+    textAlign: { textAlign: "right" as const },
+  },
+  icon: {
+    base: "h-3 w-3",
+    check: "text-green-500",
+    clipboard:
+      "text-slate-500 dark:text-slate-400 hover:text-brand-primary dark:hover:text-brand-primary",
+  },
+};
+
+/**
+ * A component that renders plaintext content with a copy button.
+ */
+export default function PlaintextPanel({
+  className,
+  codeClassName,
+  content,
+  copyTitle = "Text",
+  rawText,
+}: PlaintextPanelProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copyToClipboard = () => {
+    const textContent = rawText || extractTextFromNode(content);
+    navigator.clipboard.writeText(textContent).then(
+      () => {
+        setIsCopied(true);
+        toast.custom((t) => (
+          <ToastContentSuccess
+            message={`${copyTitle} copied to clipboard`}
+            t={t}
+          />
+        ));
+        setTimeout(() => {
+          setIsCopied(false);
+        }, 2000);
+      },
+      (err) => {
+        console.error("Failed to copy text: ", err);
+      },
+    );
+  };
+
+  return (
+    <div
+      className={`${styleConfig.container.base} ${className || ""}`}
+      style={styleConfig.container.font}
+    >
+      {/* Header with copy button */}
+      <div
+        className={styleConfig.header.base}
+        style={styleConfig.header.textAlign}
+      >
+        <button
+          className="inline-flex cursor-pointer items-center rounded p-1"
+          data-testid="text-copy-button"
+          onClick={copyToClipboard}
+          tabIndex={0}
+          title="Copy to clipboard"
+          type="button"
+        >
+          {isCopied ? (
+            <CheckIcon
+              aria-hidden="true"
+              className={`${styleConfig.icon.base} ${styleConfig.icon.check}`}
+            />
+          ) : (
+            <ClipboardIcon
+              aria-hidden="true"
+              className={`${styleConfig.icon.base} ${styleConfig.icon.clipboard}`}
+            />
+          )}
+        </button>
+      </div>
+      {/* Content block */}
+      <div
+        className={styleConfig.content.base}
+        style={styleConfig.content.layout}
+      >
+        <code className={`${styleConfig.content.code} ${codeClassName || ""}`}>
+          {content}
+        </code>
+      </div>
+    </div>
+  );
+}
+
+// Helper function to extract text from React nodes
+function extractTextFromNode(node: React.ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return node.toString();
+  if (Array.isArray(node)) return node.map(extractTextFromNode).join(" ");
+  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    const children = node.props.children;
+    if (children) return extractTextFromNode(children);
+  }
+  return "";
+}

--- a/src/components/WorkflowDetail.tsx
+++ b/src/components/WorkflowDetail.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@components/Button";
 import { Subheading } from "@components/Heading";
+import JSONView from "@components/JSONView";
 import RelativeTimeFormatter from "@components/RelativeTimeFormatter";
 import { TaskStateIcon } from "@components/TaskStateIcon";
 import TopNavTitleOnly from "@components/TopNavTitleOnly";
@@ -179,18 +180,17 @@ const SelectedJobDetails = ({
         <div className="col-span-2 border-t border-slate-100 py-4 text-sm sm:col-span-1 sm:px-0 dark:border-slate-800">
           <dt className={dtClasses}>Args</dt>
           <dd className={clsx(ddClasses, "text-base leading-6 sm:text-sm")}>
-            <pre className="overflow-scroll bg-slate-300/10 p-4 font-mono text-slate-900 dark:bg-slate-700/10 dark:text-slate-100">
-              {JSON.stringify(job.args, null, 2)}
-            </pre>
+            <JSONView copyTitle="Args" data={job.args} />
           </dd>
         </div>
         <div className="col-span-2 border-t border-slate-100 py-4 text-sm sm:col-span-1 sm:px-0 dark:border-slate-800">
           <dt className={dtClasses}>Metadata</dt>
           <dd className={clsx(ddClasses, "text-base leading-6 sm:text-sm")}>
-            {/* <dd className="mt-1 text-sm leading-6  text-slate-700 dark:text-slate-300 sm:mt-2"> */}
-            <pre className="overflow-scroll bg-slate-300/10 p-4 font-mono text-slate-800 dark:bg-slate-700/10 dark:text-slate-200">
-              {JSON.stringify(job.metadata, null, 2)}
-            </pre>
+            <JSONView
+              copyTitle="Metadata"
+              data={job.metadata}
+              defaultExpandDepth={0}
+            />
           </dd>
         </div>
       </div>


### PR DESCRIPTION
As we start looking at having larger metadata payloads (for job logs) the prior approach of pretty-printing the entire thing on screen is unsustainable. This is also true for users with large arg payloads.

As such, move to an interactive collapsible JSON tree view. By default, it expands the first level and collapses any nested arrays or objects.

https://github.com/user-attachments/assets/3f9c09d6-4581-4228-acf7-0702098d40ac

