### PR TITLE
use Link component on QueueList page, not raw <a> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Job args and metadata on the job detail view now use an interactive collapsible JSON view rather than pretty-printing the entire payload on screen. For large payloads this is a better UX and doesn't disrupt the page flow by default. [PR #351](https://github.com/riverqueue/riverui/pull/351).
 
+### Fixed
+
+- Corrected links on queue list page to use the TanStack Router `<Link>` component instead of raw `<a>` tags so that settings like path prefix will be respected. [PR #353](https://github.com/riverqueue/riverui/pull/353).
+
 ## [v0.9.0] - 2025-04-08
 
 ### Added

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -2,6 +2,7 @@ import RelativeTimeFormatter from "@components/RelativeTimeFormatter";
 import TopNavTitleOnly from "@components/TopNavTitleOnly";
 import { PauseCircleIcon, PlayCircleIcon } from "@heroicons/react/24/outline";
 import { Queue } from "@services/queues";
+import { Link } from "@tanstack/react-router";
 
 type QueueListProps = {
   loading: boolean;
@@ -72,12 +73,13 @@ const QueueList = ({
                 <tr key={queue.name}>
                   <td className="w-full max-w-0 py-2 pr-3 pl-4 text-sm font-medium text-slate-700 sm:w-auto sm:max-w-none sm:pl-0 dark:text-slate-300">
                     <span className="font-mono font-semibold dark:text-slate-100">
-                      <a
+                      <Link
                         className="text-slate-900 dark:text-slate-200"
-                        href={`/queues/${queue.name}`}
+                        params={{ name: queue.name }}
+                        to="/queues/$name"
                       >
                         {queue.name}
-                      </a>
+                      </Link>
                     </span>
                     <dl className="font-normal md:hidden">
                       <dt className="sr-only sm:hidden">Available</dt>


### PR DESCRIPTION
Without using the TanStack Router `<Link>` component, router-level settings like prefixes will not be factored in. This means any links within the app need to use it, and the recently updated QueueList page did not do so until this commit.

Fixes #352.