### PR TITLE
JobSearch rewrite to use single input field for native UX

### DIFF
--- a/src/components/JobList.tsx
+++ b/src/components/JobList.tsx
@@ -325,16 +325,19 @@ const JobRows = ({
     <div className="flex min-h-dvh flex-col">
       <div className="px-4 sm:px-6 lg:px-8">
         <div className="flex min-h-16 items-center space-x-4 border-b border-slate-300 py-2 sm:justify-between dark:border-slate-700">
-          {jobs.length > 0 && (
+          <div className="w-6">
             <CustomCheckbox
               aria-label={"Select all jobs"}
               checked={selectedJobs.length > 0}
-              className="grow-0"
+              className={classNames(
+                "grow-0",
+                jobs.length === 0 ? "invisible" : "",
+              )}
               indeterminate={isIndeterminate}
               name={"select_all_jobs"}
               onChange={handleSelectAll}
             />
-          )}
+          </div>
           <JobSearch
             className={classNames(selectedJobs.length === 0 ? "" : "hidden")}
             initialFilters={initialFilters}

--- a/src/components/job-search/JobSearch.test.tsx
+++ b/src/components/job-search/JobSearch.test.tsx
@@ -4,7 +4,6 @@ import {
   render,
   screen,
   waitFor,
-  within,
 } from "@testing-library/react";
 import { userEvent } from "storybook/test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,37 +16,6 @@ declare module "vitest" {
     toBeInTheDocument(): T;
   }
 }
-
-// Helper to get the Badge root element (outer span) for a given filter typeId
-const getBadgeRootByTypeId = (typeId: string): HTMLElement => {
-  const badgeRoot = screen.getByTestId(`filter-badge-${typeId}`);
-  if (!badgeRoot) throw new Error(`Badge root for typeId ${typeId} not found`);
-  return badgeRoot;
-};
-
-// Helper to open the filter type dropdown
-const openFilterTypeDropdown = async () => {
-  const searchInput = screen.getByPlaceholderText("Add filter");
-  fireEvent.focus(searchInput);
-  // Wait for any filter type suggestion to appear (e.g., 'kind')
-  await waitFor(() => {
-    expect(screen.getByTestId("suggestion-kind")).toBeInTheDocument();
-  });
-};
-
-// Helper to select a filter type by its label (e.g., 'kind', 'id', etc.)
-const selectFilterType = async (label: string) => {
-  await openFilterTypeDropdown();
-  const searchInput = screen.getByTestId("job-search-input");
-  fireEvent.focus(searchInput);
-  await userEvent.type(searchInput, label);
-  // Wait for the specific filter type suggestion to appear
-  await waitFor(() => {
-    expect(screen.getByTestId(`suggestion-${label}`)).toBeInTheDocument();
-  });
-  // Click the suggestion using userEvent to better simulate user interaction
-  await userEvent.click(screen.getByText(label));
-};
 
 describe("JobSearch", () => {
   beforeEach(() => {
@@ -94,577 +62,71 @@ describe("JobSearch", () => {
     }));
   });
 
-  it("renders with initial filters", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // The badge root span should exist
-    await waitFor(() =>
-      expect(screen.getByTestId("filter-badge-kind")).toBeInTheDocument(),
-    );
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    expect(badgeRoot).toBeInTheDocument();
-
-    // Verify the input inside the filter has the correct value
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(input.getAttribute("value")).toBe("batch");
-  });
-
-  it("has password manager prevention attributes on search input", () => {
-    render(<JobSearch />);
-    const searchInput = screen.getByTestId("job-search-input");
-    expect(searchInput).toHaveAttribute("data-1p-ignore");
-    expect(searchInput).toHaveAttribute("data-form-type", "other");
-    expect(searchInput).toHaveAttribute("autoComplete", "off");
-  });
-
-  it("allows adding a new filter", async () => {
-    const onFiltersChange = vi.fn();
-    render(<JobSearch onFiltersChange={onFiltersChange} />);
-
-    await selectFilterType("kind");
-
-    // Verify the filter was added - find the badge with kind: prefix
-    const filterElement = screen.getByText("kind:").closest("span");
-    expect(filterElement).toBeInTheDocument();
-
-    expect(onFiltersChange).toHaveBeenCalledWith([
-      expect.objectContaining({
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      }),
-    ]);
-  });
-
-  it("allows removing a filter", () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    const onFiltersChange = vi.fn();
-    render(
-      <JobSearch
-        initialFilters={initialFilters}
-        onFiltersChange={onFiltersChange}
-      />,
-    );
-
-    // Find the kind: badge root
-    const badgeRoot = getBadgeRootByTypeId("kind");
-
-    // Click the remove button within the badge
-    const removeButton = within(badgeRoot).getByRole("button", {
-      name: /remove filter/i,
-    });
-    fireEvent.click(removeButton);
-
-    // Verify the filter was removed
-    expect(screen.queryByText("kind:")).not.toBeInTheDocument();
-    expect(onFiltersChange).toHaveBeenCalledWith([]);
-  });
-
-  it("shows suggestions when editing a filter", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Get the input element inside the badge
-    const input = within(badgeRoot).getByRole("textbox");
-
-    // Type to trigger suggestions
-    await userEvent.type(input, "b");
-
-    // Verify suggestions appear
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
-    });
-  });
-
-  it("allows selecting a suggestion with keyboard navigation", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type to trigger suggestions
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "b");
-
-    // Wait for suggestions
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
-    });
-
-    // Press Down arrow to navigate to the first suggestion
-    fireEvent.keyDown(input, { key: "ArrowDown" });
-
-    // Press Enter to select the suggestion
-    fireEvent.keyDown(input, { key: "Enter" });
-
-    // Verify the suggestion was applied
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("batch");
-    });
-  });
-
-  it("clears all filters when clicking the clear button", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    const onFiltersChange = vi.fn();
-    render(
-      <JobSearch
-        initialFilters={initialFilters}
-        onFiltersChange={onFiltersChange}
-      />,
-    );
-
-    // Find the clear button (XMarkIcon) which might be inside or near the search input container
-    const searchContainer = screen
-      .getByPlaceholderText("Add filter")
-      .closest("div");
-    // Look for any button within the search container or its parent that might be the clear button
-    const buttons = within(searchContainer!.parentElement!).getAllByRole(
-      "button",
-    );
-    // Assuming the clear button is the last button or has a specific characteristic
-    const clearButton = buttons[buttons.length - 1];
-    fireEvent.click(clearButton);
-
-    // Verify all filters were cleared
-    expect(screen.queryByText("kind:")).not.toBeInTheDocument();
-    expect(onFiltersChange).toHaveBeenCalledWith([]);
-  });
-
-  it("handles multiple filter values", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type a comma to add another value
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, ",");
-
-    // Type to trigger suggestions
-    await userEvent.type(input, "s");
-
-    // Wait for suggestions
-    await waitFor(() => {
-      expect(screen.getByText("scheduled")).toBeInTheDocument();
-    });
-
-    // Click the suggestion
-    await act(async () => {
-      fireEvent.mouseDown(screen.getByText("scheduled"));
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // Press Enter to exit edit mode
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // After exiting edit mode, values should be sorted
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("batch,scheduled");
-    });
-  });
-
-  it("focuses existing badge when adding a filter type that already exists", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    await selectFilterType("kind");
-
-    // Verify the existing filter is in edit mode (editable)
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const filterInput = within(badgeRoot).getByRole("textbox");
-    expect(filterInput.getAttribute("value")).toBe("batch,"); // Should have trailing comma for easy addition
-    expect(document.activeElement).toBe(filterInput);
-  });
-
-  it("shows autocomplete dropdown when typing a comma for a new value", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type a comma for a new value
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, ",");
-
-    // Verify dropdown shows suggestions for empty input
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-  });
-
-  it("appends comma and shows autocomplete suggestions when editing an existing value list", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch", "stream"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter input directly to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.click(input);
-    });
-
-    // Verify a comma is appended to the input (wait for UI update if needed)
-    await waitFor(
-      () => {
-        expect(input.getAttribute("value")).toBe("batch,stream,");
-      },
-      { timeout: 3000 },
-    );
-
-    // Verify autocomplete suggestions are shown immediately
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-  });
-
-  it("shows autocomplete suggestions immediately after adding a new kind filter", async () => {
-    render(<JobSearch />);
-
-    // Add a new Job Kind filter
-    await selectFilterType("kind");
-
-    // Verify the filter is in edit mode and suggestions are shown
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(input);
-
-    // Verify autocomplete suggestions are shown immediately
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-  });
-
-  it("selects a suggestion with mouse click at the correct position", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type to trigger suggestions
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "b");
-
-    // Wait for suggestions
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
-    });
-
-    // Click the suggestion with mouse
-    await act(async () => {
-      fireEvent.mouseDown(screen.getByText("batch"));
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // Verify the suggestion was inserted at the correct position
-    await waitFor(() => {
-      expect(input.getAttribute("value")).toBe("batch");
-    });
-
-    // Exit edit mode
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // Verify final value
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("batch");
-    });
-  });
-
-  it("saves current input when pressing Enter with no suggestion highlighted", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type a custom value not in suggestions
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "custom-kind");
-
-    // Press Enter to save it (with no suggestion highlighted)
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // Verify the custom input was saved
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("custom-kind");
-    });
-  });
-
-  it("sorts and deduplicates values when exiting edit mode", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type multiple values with duplicates and out of order
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "stream,batch,stream");
-
-    // Press Enter to save and exit edit mode
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // Verify values are sorted and deduplicated
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("batch,stream");
-    });
-  });
-
-  it("ensures the input region is always clickable even when empty", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Verify the badge with empty values is in the document
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    expect(badgeRoot).toBeInTheDocument();
-
-    // Click input inside badge to enter edit mode
-    const input = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.click(input);
-    });
-
-    // Verify edit mode was entered
-    expect(document.activeElement).toBe(input);
-  });
-
-  it("ensures no duplicate filter types can be added", async () => {
-    const onFiltersChange = vi.fn();
-    render(<JobSearch onFiltersChange={onFiltersChange} />);
-
-    // Add the first filter
-    const searchInput = screen.getByTestId("job-search-input");
-    await act(async () => {
-      fireEvent.focus(searchInput);
-      await userEvent.type(searchInput, "kind");
-    });
-
-    // Wait for the filter type dropdown to appear
-    await waitFor(() => {
-      // Look for the button containing 'kind' text instead of data-testid
-      const kindButton = screen.getByRole("button", { name: /^kind$/i });
-      expect(kindButton).toBeInTheDocument();
-    });
-
-    // Click the kind button directly
-    await act(async () => {
-      const kindButton = screen.getByRole("button", { name: /^kind$/i });
-      fireEvent.mouseDown(kindButton);
-    });
-
-    // Exit edit mode on the existing filter to mimic user finishing editing
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const existingInput = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.keyDown(existingInput, { key: "Enter" });
-    });
-
-    // Try to add the same filter type again
-    await act(async () => {
-      fireEvent.focus(searchInput);
-      await userEvent.type(searchInput, "kind");
-    });
-
-    // Wait for the kind button to appear again
-    await waitFor(() => {
-      const kindButton = screen.getByRole("button", { name: /^kind$/i });
-      expect(kindButton).toBeInTheDocument();
-    });
-
-    // Click the kind button again
-    await act(async () => {
-      const kindButtonAgain = screen.getByRole("button", { name: /^kind$/i });
-      fireEvent.mouseDown(kindButtonAgain);
-    });
-
-    // Verify there's only one "kind:" badge
-    const kindFilters = screen.getAllByText("kind:");
-    expect(kindFilters.length).toBe(1);
-
-    // Verify the existing filter is in edit mode
-    const updatedBadge = getBadgeRootByTypeId("kind");
-    expect(updatedBadge).toHaveClass("ring-2"); // Check for edit mode styling
-  });
-
-  it("notifies parent of all filter changes", async () => {
-    const onFiltersChange = vi.fn();
-    render(<JobSearch onFiltersChange={onFiltersChange} />);
-
-    // Add a filter
-    await selectFilterType("kind");
-
-    // Verify onFiltersChange was called with the new filter
-    await waitFor(() => {
-      expect(onFiltersChange).toHaveBeenCalledWith([
-        expect.objectContaining({
+  describe("Basic Rendering & Props", () => {
+    it("renders with initial filters", async () => {
+      const initialFilters: Filter[] = [
+        {
+          id: "1",
           prefix: "kind:",
           typeId: FilterTypeId.KIND,
-          values: [],
-        }),
-      ]);
+          values: ["batch"],
+        },
+      ];
+      render(<JobSearch initialFilters={initialFilters} />);
+
+      const searchInput = screen.getByTestId("job-search-input");
+      expect(searchInput.getAttribute("value")).toBe("kind:batch");
     });
 
-    // Reset the mock
-    onFiltersChange.mockClear();
-
-    // Edit the filter
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    const filterInput = within(badgeRoot).getByRole("textbox");
-    // Type batch and save
-    await userEvent.type(filterInput, "batch");
-    await act(async () => {
-      fireEvent.keyDown(filterInput, { key: "Enter" });
+    it("has password manager prevention attributes on search input", () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+      expect(searchInput).toHaveAttribute("data-1p-ignore");
+      expect(searchInput).toHaveAttribute("data-form-type", "other");
+      expect(searchInput).toHaveAttribute("autoComplete", "off");
     });
 
-    // Verify onFiltersChange was called with the updated filter
-    await waitFor(() => {
+    it("notifies parent of filter changes", async () => {
+      const onFiltersChange = vi.fn();
+      render(<JobSearch onFiltersChange={onFiltersChange} />);
+
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch");
+      });
+
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith([
+          expect.objectContaining({
+            prefix: "kind:",
+            typeId: FilterTypeId.KIND,
+            values: ["batch"],
+          }),
+        ]);
+      });
+    });
+
+    it("debounces filter changes", async () => {
+      const onFiltersChange = vi.fn();
+      render(<JobSearch onFiltersChange={onFiltersChange} />);
+
+      const searchInput = screen.getByTestId("job-search-input");
+
+      // Type quickly
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch");
+      });
+
+      // Should not have called onFiltersChange immediately
+      expect(onFiltersChange).not.toHaveBeenCalled();
+
+      // Wait for debounce
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+
+      // Should have called onFiltersChange after debounce
       expect(onFiltersChange).toHaveBeenCalledWith([
         expect.objectContaining({
           prefix: "kind:",
@@ -673,1351 +135,616 @@ describe("JobSearch", () => {
         }),
       ]);
     });
-
-    // Reset the mock
-    onFiltersChange.mockClear();
-
-    // Remove the filter
-    const updatedBadge = getBadgeRootByTypeId("kind");
-    const removeButton = within(updatedBadge).getByRole("button", {
-      name: /remove filter/i,
-    });
-    await act(async () => {
-      fireEvent.click(removeButton);
-    });
-
-    // Verify onFiltersChange was called with empty filters
-    await waitFor(() => {
-      expect(onFiltersChange).toHaveBeenCalledWith([]);
-    });
   });
 
-  it("selects a suggestion when hovering and pressing Enter", async () => {
-    const initialFilters = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
+  describe("Suggestion System", () => {
+    it("shows filter type suggestions when typing", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
+      await act(async () => {
+        await userEvent.type(searchInput, "k");
+      });
 
-    // Type to trigger suggestions
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "b");
-
-    // Wait for suggestions
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
-    });
-
-    // Simulate hovering over the first suggestion
-    const suggestionButton = screen.getByText("batch");
-    fireEvent.mouseEnter(suggestionButton);
-
-    // Press Enter to select the highlighted suggestion
-    fireEvent.keyDown(input, { key: "Enter" });
-
-    // Verify the suggestion was applied
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("batch");
-    });
-  });
-
-  it("shows autocomplete suggestions when clicking into an existing value list with trailing comma", async () => {
-    const initialFilters = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch", "stream"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter input directly to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.click(input);
-    });
-
-    // Verify a comma is appended to the input
-    await waitFor(
-      () => {
-        expect(input.getAttribute("value")).toBe("batch,stream,");
-      },
-      { timeout: 3000 },
-    );
-
-    // Verify autocomplete suggestions are shown for the new empty token
-    await waitFor(
-      () => {
+      await waitFor(() => {
         expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-  });
-
-  it("provides autocomplete suggestions for mid-list edits and correctly replaces the edited value with cursor at updated item end", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch", "stream", "scheduled"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Simulate editing the first value (batch to bat)
-    const input = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          selectionEnd: 3,
-          selectionStart: 3,
-          value: "bat,stream,scheduled",
-        },
+        expect(screen.getByTestId("suggestion-kind")).toBeInTheDocument();
       });
     });
 
-    // Verify suggestions appear for 'bat', should include 'batch'
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
+    it("filters suggestions based on current input", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "pri");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("suggestion-priority")).toBeInTheDocument();
+        expect(screen.queryByTestId("suggestion-kind")).not.toBeInTheDocument();
+      });
     });
 
-    // Select the suggestion 'batch'
-    fireEvent.mouseDown(screen.getByText("batch"));
+    it("shows value suggestions after selecting a filter type", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Verify the filter list is updated correctly, replacing the first item
-    // and cursor is at the end of the updated item 'batch' (position 5)
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole(
-        "textbox",
-      ) as HTMLInputElement;
-      expect(updatedInput.getAttribute("value")).toBe("batch,stream,scheduled");
-      expect(updatedInput.selectionStart).toBe(5); // End of 'batch'
-      expect(updatedInput.selectionEnd).toBe(5);
-    });
-  });
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:");
+      });
 
-  it("hides suggestions dropdown after selecting a suggestion", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type to trigger suggestions
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "b");
-
-    // Wait for suggestions
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
-    });
-
-    // Click the suggestion
-    fireEvent.mouseDown(screen.getByText("batch"));
-
-    // Verify the dropdown is hidden after selection
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("suggestions-dropdown"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("shows autocomplete suggestions after selecting a suggestion and typing a comma", async () => {
-    render(<JobSearch />);
-
-    // Add a new filter
-    await selectFilterType("kind");
-
-    // Get the filter badge
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(input);
-
-    // Verify suggestions are shown
-    await waitFor(
-      () => {
+      await waitFor(() => {
         expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-
-    // Type to trigger specific suggestion
-    await userEvent.type(input, "b");
-
-    // Wait for 'batch' suggestion
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
-    });
-
-    // Click the suggestion
-    fireEvent.mouseDown(screen.getByText("batch"));
-
-    // Wait for suggestion to be applied
-    await waitFor(() => {
-      expect(input.getAttribute("value")).toBe("batch");
-    });
-
-    // Now type a comma to add another value
-    await userEvent.type(input, ",");
-
-    // Verify autocomplete suggestions are shown again
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-  });
-
-  it("correctly replaces a middle value with suggestion rather than appending it", async () => {
-    // Setup initial filter with 3 values
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["AITrainingBatch", "Chaos", "UtilizeNewModel"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Simulate editing the middle value by placing cursor after "Chaos" and removing a character
-    const input = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          selectionEnd: 15 + 5, // AITrainingBatch, + cursor after the "s" in Chaos
-          selectionStart: 15 + 5,
-          value: "AITrainingBatch,Chao,UtilizeNewModel",
-        },
+        expect(screen.getByTestId("suggestion-batch")).toBeInTheDocument();
       });
     });
 
-    // Verify suggestions appear for 'Chao', should include 'Chaos'
-    await waitFor(() => {
-      expect(screen.getByText("Chaos")).toBeInTheDocument();
-    });
+    it("shows value suggestions that filter based on existing values", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Select the suggestion 'Chaos'
-    fireEvent.mouseDown(screen.getByText("Chaos"));
-
-    // Verify the filter value is correctly updated with 'Chaos' replacing 'Chao'
-    // rather than being appended to the end
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      const value = updatedInput.getAttribute("value");
-      expect(value).toBe("AITrainingBatch,Chaos,UtilizeNewModel");
-      expect(value).not.toContain("AITrainingBatch,Chao,UtilizeNewModel,Chaos");
-    });
-  });
-
-  it("shows autocomplete suggestions when creating a gap between values with two commas", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["foo", "bar", "baz"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Get the input and simulate editing
-    const input = within(badgeRoot).getByRole("textbox");
-
-    // Add a comma after 'bar' to create a gap
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          selectionEnd: 8,
-          selectionStart: 8,
-          value: "foo,bar,,baz",
-        },
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch,");
       });
-    });
 
-    // Verify suggestions dropdown appears for empty value between commas
-    await waitFor(() => {
-      expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-      const suggestionsList = screen.getByTestId("suggestions-list");
-      expect(suggestionsList).toBeInTheDocument();
-      // Verify we have suggestions (should show all options since no filter)
-      const buttons = within(suggestionsList).getAllByRole("button");
-      expect(buttons.length).toBeGreaterThan(0);
-    });
-  });
-
-  it("removes focus from input when edit mode ends", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    const onFiltersChange = vi.fn();
-    render(
-      <JobSearch
-        initialFilters={initialFilters}
-        onFiltersChange={onFiltersChange}
-      />,
-    );
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    await act(async () => {
-      fireEvent.click(badgeRoot);
-    });
-
-    // Get the input and verify it's focused
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(input);
-
-    // Set the input value with an empty value (,,) that should be removed on finalizing
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          value: "batch,,stream",
-        },
-      });
-    });
-
-    // Press Enter to exit edit mode
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-    });
-
-    // Verify that filter values were properly updated in the filter state
-    // This is what actually matters, even if the UI display is different
-    expect(onFiltersChange).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          typeId: FilterTypeId.KIND,
-          values: ["batch", "stream"],
-        }),
-      ]),
-    );
-  });
-
-  it("does not show suggestions dropdown after selecting a suggestion with keyboard", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type to trigger suggestions
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "b");
-
-    // Wait for suggestions
-    await waitFor(() => {
-      expect(screen.getByText("batch")).toBeInTheDocument();
-    });
-
-    // Navigate to the first suggestion with keyboard
-    fireEvent.keyDown(input, { key: "ArrowDown" });
-
-    // Select the suggestion with Enter
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // Verify the suggestion was applied
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("batch");
-    });
-
-    // Verify the suggestions dropdown is hidden after selection
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("suggestions-dropdown"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("shows autocomplete suggestions for a new entry when editing a filter with a single value", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Get the input and verify cursor position
-    const input = within(badgeRoot).getByRole("textbox") as HTMLInputElement;
-    await waitFor(() => {
-      expect(input.getAttribute("value")).toBe("batch,");
-      expect(input.selectionStart).toBe(6); // Should be after the comma
-      expect(input.selectionEnd).toBe(6);
-    });
-
-    // Verify suggestions are shown for a new entry (not for 'batch')
-    await waitFor(() => {
-      expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-      const suggestionsList = screen.getByTestId("suggestions-list");
-      const buttons = within(suggestionsList).getAllByRole("button");
-      expect(buttons.length).toBeGreaterThan(0);
-      // Check that suggestions include items other than 'batch'
-      const suggestionTexts = buttons.map((btn) => btn.textContent);
-      expect(suggestionTexts.some((text) => text !== "batch")).toBe(true);
-    });
-  });
-
-  it("hides autocomplete suggestions after selecting a replacement value in the middle of a list", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["foo", "bar", "baz"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Simulate editing the middle value by placing cursor after 'bar' and deleting it
-    const input = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          selectionEnd: 7, // After 'r' in 'bar'
-          selectionStart: 4, // Before 'bar'
-          value: "foo,,baz",
-        },
-      });
-    });
-
-    // Verify input value is correct after deletion
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("foo,,baz");
-    });
-
-    // Simulate typing 'ba' in the empty spot
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          selectionEnd: 5, // After 'a' in 'ba'
-          selectionStart: 5,
-          value: "foo,ba,baz",
-        },
-      });
-    });
-
-    // Verify input value is correct after typing
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("foo,ba,baz");
-    });
-
-    // Verify suggestions appear for 'ba'
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByText("batch")).toBeInTheDocument();
-      },
-      { timeout: 3000 },
-    );
-
-    // Select the suggestion 'batch'
-    await act(async () => {
-      fireEvent.mouseDown(screen.getByText("batch"));
-      // Wait for state updates to complete
-      await Promise.resolve();
-    });
-
-    // Verify the filter value is updated correctly
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("foo,batch,baz");
-    });
-
-    // Verify the suggestions dropdown is hidden after selection
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("suggestions-dropdown"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("shows autocomplete suggestions when backspacing the first value of a newly added filter", async () => {
-    render(<JobSearch />);
-
-    // Add a new filter
-    await selectFilterType("kind");
-
-    // Get the filter badge
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(input);
-
-    // Type to add two values
-    await userEvent.type(input, "batch,stream");
-
-    // Move cursor to after 'batch' and backspace
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          selectionEnd: 5,
-          selectionStart: 5,
-          value: "batch,stream",
-        },
-      });
-      // Simulate backspace by setting the value explicitly
-      fireEvent.change(input, {
-        target: {
-          selectionEnd: 4,
-          selectionStart: 4,
-          value: "batc,stream",
-        },
-      });
-    });
-
-    // Verify input value is correct after backspace
-    await waitFor(
-      () => {
-        expect(input.getAttribute("value")).toBe("batc,stream");
-      },
-      { timeout: 3000 },
-    );
-
-    // Verify suggestions are shown for 'batc'
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
+      await waitFor(() => {
         const suggestionsList = screen.getByTestId("suggestions-list");
-        const suggestionButtons =
-          within(suggestionsList).getAllByRole("button");
-        expect(suggestionButtons.length).toBeGreaterThan(0);
-        const suggestionTexts = suggestionButtons.map((btn) => btn.textContent);
-        expect(suggestionTexts).toContain("batch");
-      },
-      { timeout: 3000 },
-    );
-  });
+        const buttons = suggestionsList.querySelectorAll("button");
+        const suggestionTexts = Array.from(buttons).map(
+          (btn) => btn.textContent,
+        );
 
-  it("emits updated filters during editing for live search refreshing", async () => {
-    const onFiltersChange = vi.fn();
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(
-      <JobSearch
-        initialFilters={initialFilters}
-        onFiltersChange={onFiltersChange}
-      />,
-    );
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Type a new value to trigger filter update during editing
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, ",stream");
-
-    // Verify onFiltersChange was called with the updated filter values during editing
-    await waitFor(() => {
-      expect(onFiltersChange).toHaveBeenCalledWith([
-        expect.objectContaining({
-          prefix: "kind:",
-          typeId: FilterTypeId.KIND,
-          values: ["batch", "stream"],
-        }),
-      ]);
+        // Should show suggestions but not include "batch" since it's already selected
+        expect(suggestionTexts).toContain("stream");
+        expect(suggestionTexts).not.toContain("batch");
+      });
     });
-  });
 
-  it("allows adding a new Job ID filter without autocomplete suggestions", async () => {
-    const onFiltersChange = vi.fn();
-    render(<JobSearch onFiltersChange={onFiltersChange} />);
+    it("shows suggestions immediately after applying filter type", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    await selectFilterType("id");
+      await act(async () => {
+        await userEvent.type(searchInput, "kind");
+      });
 
-    // Verify the filter was added - find the badge with id: prefix
-    const filterElement = screen.getByText("id:").closest("span");
-    expect(filterElement).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId("suggestion-kind")).toBeInTheDocument();
+      });
 
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("id");
-    fireEvent.click(badgeRoot);
+      await act(async () => {
+        fireEvent.mouseDown(screen.getByText("kind"));
+      });
 
-    // Type a value to ensure no suggestions appear
-    const input = within(badgeRoot).getByRole("textbox");
-    await userEvent.type(input, "123");
+      // Wait for both the suggestion application and the subsequent suggestion loading
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
 
-    // Verify no suggestions dropdown appears
-    await waitFor(
-      () => {
+      // Should immediately show value suggestions
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("kind:");
+        expect(screen.getByTestId("suggestion-batch")).toBeInTheDocument();
+      });
+    });
+
+    it("supports ID filter without suggestions", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "id:12345");
+      });
+
+      // Should not show suggestions for ID values
+      await waitFor(() => {
         expect(
           screen.queryByTestId("suggestions-dropdown"),
         ).not.toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
+      });
 
-    // Press Enter to save the value
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-      await Promise.resolve();
-    });
-
-    // Verify the value was saved
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("id");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("123");
-    });
-
-    // Verify onFiltersChange was called with the new filter
-    expect(onFiltersChange).toHaveBeenCalledWith([
-      expect.objectContaining({
-        prefix: "id:",
-        typeId: FilterTypeId.ID,
-        values: ["123"],
-      }),
-    ]);
-  });
-
-  it("shows filter type suggestions as you type and allows keyboard selection", async () => {
-    render(<JobSearch />);
-    await waitFor(() => {
-      expect(screen.getByTestId("job-search-input")).toBeInTheDocument();
-    });
-    const input = screen.getByTestId("job-search-input");
-    // Focus input and type 'k'
-    await act(async () => {
-      input.focus();
-      await userEvent.type(input, "k");
-    });
-
-    // Verify suggestions appear and 'kind' is highlighted
-    await waitFor(() => {
-      expect(screen.getByText("kind")).toBeInTheDocument();
-    });
-
-    // Press Enter to select the highlighted suggestion
-    fireEvent.keyDown(input, { code: "Enter", key: "Enter" });
-
-    // Verify the filter is added
-    await waitFor(() => {
-      expect(screen.getByTestId("filter-badge-kind")).toBeInTheDocument();
+      expect(searchInput.getAttribute("value")).toBe("id:12345");
     });
   });
 
-  it("filters filter type suggestions as you type", async () => {
-    render(<JobSearch />);
-    const input = screen.getByTestId("job-search-input");
-    await act(async () => {
-      input.focus();
-      await userEvent.type(input, "pri");
+  describe("User Interactions", () => {
+    it("allows selecting a filter type suggestion", async () => {
+      const onFiltersChange = vi.fn();
+      render(<JobSearch onFiltersChange={onFiltersChange} />);
+
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "kind");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("suggestion-kind")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.mouseDown(screen.getByText("kind"));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("kind:");
+      });
+
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith([
+          expect.objectContaining({
+            prefix: "kind:",
+            typeId: FilterTypeId.KIND,
+            values: [],
+          }),
+        ]);
+      });
     });
 
-    // Verify only 'priority' is shown, not 'kind'
-    await waitFor(() => {
-      expect(screen.getByText("priority")).toBeInTheDocument();
-      expect(screen.queryByText("kind")).not.toBeInTheDocument();
-    });
-  });
+    it("allows selecting value suggestions", async () => {
+      const onFiltersChange = vi.fn();
+      render(<JobSearch onFiltersChange={onFiltersChange} />);
 
-  it("selects filter type with colon shortcut", async () => {
-    render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Get the input element first
-    const input = screen.getByTestId("job-search-input");
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:");
+      });
 
-    // Wrap all state changes in a single act call
-    await act(async () => {
-      // Focus the input first
-      fireEvent.focus(input);
+      await waitFor(() => {
+        expect(screen.getByTestId("suggestion-batch")).toBeInTheDocument();
+      });
 
-      // Use a normal fireEvent with a colon shortcut
-      fireEvent.change(input, { target: { value: "queue:" } });
+      await act(async () => {
+        fireEvent.mouseDown(screen.getByText("batch"));
+      });
 
-      // Fire a keyDown event to trigger the colon shortcut handler
-      fireEvent.keyDown(input, { key: ":" });
-    });
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("kind:batch");
+      });
 
-    // Verify the filter was added
-    await waitFor(() => {
-      expect(screen.getByTestId("filter-badge-queue")).toBeInTheDocument();
-    });
-  });
-
-  it("closes filter type suggestions and clears input on Escape", async () => {
-    render(<JobSearch />);
-    const input = screen.getByTestId("job-search-input");
-    await act(async () => {
-      input.focus();
-      await userEvent.type(input, "ki");
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith([
+          expect.objectContaining({
+            prefix: "kind:",
+            typeId: FilterTypeId.KIND,
+            values: ["batch"],
+          }),
+        ]);
+      });
     });
 
-    // Verify suggestions appear
-    await waitFor(() => {
-      expect(screen.getByText("kind")).toBeInTheDocument();
-    });
+    it("handles colon shortcut for filter types", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Press Escape
-    await act(async () => {
-      fireEvent.keyDown(input, { code: "Escape", key: "Escape" });
-    });
+      // Type "queue:" directly
+      await act(async () => {
+        await userEvent.type(searchInput, "queue:");
+      });
 
-    // Verify suggestions are closed and input is cleared
-    await waitFor(() => {
-      expect(screen.queryByText("kind")).not.toBeInTheDocument();
-      expect(input.getAttribute("value")).toBe("");
-    });
-  });
-
-  it("highlights first filter type suggestion by default and cycles with arrow keys", async () => {
-    render(<JobSearch />);
-    const input = screen.getByTestId("job-search-input");
-    (input as HTMLInputElement).value = "";
-    await act(async () => {
-      input.focus();
-    });
-
-    // Verify the first suggestion is highlighted
-    await waitFor(() => {
-      expect(screen.getByText("kind")).toBeInTheDocument();
-    });
-
-    // Press ArrowDown to cycle to the next suggestion
-    await act(async () => {
-      fireEvent.keyDown(input, { code: "ArrowDown", key: "ArrowDown" });
-    });
-
-    // Verify the next suggestion is highlighted (assuming 'priority' is next)
-    await waitFor(() => {
-      expect(screen.getByText("priority")).toBeInTheDocument();
-    });
-  });
-
-  it("allows arrow key navigation of suggestions immediately after adding a new filter", async () => {
-    render(<JobSearch />);
-
-    // Add a new filter
-    await selectFilterType("kind");
-
-    // Verify the filter is in edit mode
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(input);
-
-    // Verify suggestions are shown
-    await waitFor(
-      () => {
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("queue:");
+        // Should show value suggestions for queue
         expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-
-    // Press ArrowDown to navigate suggestions without typing anything
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "ArrowDown" });
+      });
     });
 
-    // Verify that the first suggestion is highlighted or selected
-    await waitFor(() => {
-      const suggestionsList = screen.getByTestId("suggestions-list");
-      const buttons = within(suggestionsList).getAllByRole("button");
-      expect(buttons[0]).toHaveClass("bg-gray-100", "dark:bg-gray-700");
-    });
-  });
-
-  it("allows arrow key navigation and selection of suggestions immediately after adding a new filter", async () => {
-    render(<JobSearch />);
-
-    // Add a new filter
-    await selectFilterType("kind");
-
-    // Verify the filter is in edit mode
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(input);
-
-    // Verify suggestions are shown
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-        expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-      },
-      { timeout: 2000 },
-    );
-
-    // Press ArrowDown to navigate suggestions without typing anything
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-    });
-
-    // Press Enter to select the highlighted suggestion
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-    });
-
-    // Verify the suggestion was applied
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      const updatedInput = within(updatedBadge).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).not.toBe("");
-    });
-  });
-
-  it("clears filter type input when leaving field without selecting a suggestion", async () => {
-    render(<JobSearch />);
-    const input = screen.getByTestId("job-search-input");
-    await act(async () => {
-      input.focus();
-      await userEvent.type(input, "xyz");
-    });
-
-    // Verify suggestions appear (or not, since 'xyz' may not match)
-    await waitFor(() => {
-      expect(input.getAttribute("value")).toBe("xyz");
-    });
-
-    // Blur the input (simulate leaving the field)
-    await act(async () => {
-      fireEvent.blur(input);
-    });
-
-    // Verify input is cleared
-    await waitFor(() => {
-      expect(input.getAttribute("value")).toBe("");
-      expect(screen.queryByText("kind")).not.toBeInTheDocument();
-      expect(screen.queryByText("priority")).not.toBeInTheDocument();
-    });
-  });
-
-  it("removes filter when pressing backspace with empty input in editable badge", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(badgeRoot);
-
-    // Clear the input
-    const input = within(badgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.change(input, {
-        target: {
-          value: "",
+    it("clears all filters when clicking the clear button", async () => {
+      const onFiltersChange = vi.fn();
+      const initialFilters: Filter[] = [
+        {
+          id: "1",
+          prefix: "kind:",
+          typeId: FilterTypeId.KIND,
+          values: ["batch"],
         },
+      ];
+      render(
+        <JobSearch
+          initialFilters={initialFilters}
+          onFiltersChange={onFiltersChange}
+        />,
+      );
+
+      const searchInput = screen.getByTestId("job-search-input");
+      expect(searchInput.getAttribute("value")).toBe("kind:batch");
+
+      // Find and click the clear button (X icon)
+      const clearButton = screen.getByRole("button");
+      await act(async () => {
+        fireEvent.click(clearButton);
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("");
+      });
+
+      // Wait for the debounced onFiltersChange callback
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith([]);
       });
     });
 
-    // Press Backspace when input is empty
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Backspace" });
-    });
+    it("applies suggestion and moves cursor correctly", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Verify the filter is removed
-    await waitFor(() => {
-      expect(screen.queryByText("kind:")).not.toBeInTheDocument();
-    });
-  });
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:bat");
+      });
 
-  it("moves cursor to end of previous filter and ensures it stays there when pressing left arrow at start of current filter", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-      {
-        id: "2",
-        prefix: "queue:",
-        typeId: FilterTypeId.QUEUE,
-        values: ["default"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
+      await waitFor(() => {
+        expect(screen.getByTestId("suggestion-batch")).toBeInTheDocument();
+      });
 
-    // Click the second filter to edit it
-    const queueBadgeRoot = getBadgeRootByTypeId("queue");
-    fireEvent.click(queueBadgeRoot);
+      await act(async () => {
+        fireEvent.mouseDown(screen.getByText("batch"));
+      });
 
-    // Verify cursor is at the end of 'default,'
-    const queueInput = within(queueBadgeRoot).getByRole(
-      "textbox",
-    ) as HTMLInputElement;
-    await waitFor(() => {
-      expect(queueInput.getAttribute("value")).toBe("default,");
-      expect(queueInput.selectionStart).toBe(8); // After the comma
-      expect(queueInput.selectionEnd).toBe(8);
-    });
-
-    // Move cursor to start of input
-    await act(async () => {
-      fireEvent.change(queueInput, {
-        target: {
-          selectionEnd: 0,
-          selectionStart: 0,
-          value: "default,",
-        },
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("kind:batch");
+        // Cursor should be at the end of "batch"
+        expect((searchInput as HTMLInputElement).selectionStart).toBe(10);
       });
     });
 
-    // Press Left Arrow to move to previous filter
-    await act(async () => {
-      fireEvent.keyDown(queueInput, { key: "ArrowLeft" });
-    });
+    it("handles cursor position correctly for autocomplete", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Verify cursor is now in the 'kind' filter at the end of 'batch,'
-    const kindBadgeRoot = getBadgeRootByTypeId("kind");
-    const kindInput = within(kindBadgeRoot).getByRole(
-      "textbox",
-    ) as HTMLInputElement;
-    await waitFor(
-      () => {
-        expect(document.activeElement).toBe(kindInput);
-        expect(kindInput.getAttribute("value")).toBe("batch,");
-        expect(kindInput.selectionStart).toBe(6); // After the comma
-        expect(kindInput.selectionEnd).toBe(6);
-      },
-      { timeout: 2000 },
-    ); // Longer timeout to catch any delayed focus shifts
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch que");
+      });
 
-    // Additional wait to ensure focus doesn't jump elsewhere (like to 'Add filter' input)
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    expect(document.activeElement).toBe(kindInput); // Should still be focused
-    expect(kindInput.selectionStart).toBe(6); // Cursor should remain at the end
-    expect(kindInput.selectionEnd).toBe(6);
-  });
+      // Place cursor after "que" to trigger filter type suggestions
+      await act(async () => {
+        fireEvent.click(searchInput);
+        (searchInput as HTMLInputElement).setSelectionRange(14, 14); // End of "que"
+        fireEvent.select(searchInput);
+      });
 
-  it("moves cursor to start of next filter when pressing right arrow at end of current filter", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-      {
-        id: "2",
-        prefix: "queue:",
-        typeId: FilterTypeId.QUEUE,
-        values: ["default"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the first filter to edit it
-    const kindBadgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(kindBadgeRoot);
-
-    // Verify cursor is at the end of 'batch,'
-    const kindInput = within(kindBadgeRoot).getByRole(
-      "textbox",
-    ) as HTMLInputElement;
-    await waitFor(() => {
-      expect(kindInput.getAttribute("value")).toBe("batch,");
-      expect(kindInput.selectionStart).toBe(6); // After the comma
-      expect(kindInput.selectionEnd).toBe(6);
-    });
-
-    // Press Right Arrow to move to next filter
-    await act(async () => {
-      fireEvent.keyDown(kindInput, { key: "ArrowRight" });
-    });
-
-    // Verify focus is now in the 'queue' filter
-    await waitFor(() => {
-      const queueBadgeRoot = getBadgeRootByTypeId("queue");
-      const queueInput = within(queueBadgeRoot).getByRole(
-        "textbox",
-      ) as HTMLInputElement;
-      expect(document.activeElement).toBe(queueInput);
-      expect(queueInput.getAttribute("value")).toBe("default,");
-      // Don't check the specific cursor position - it's not reliable across test environments
+      await waitFor(() => {
+        // Should show filter type suggestions for "que"
+        expect(screen.getByTestId("suggestion-queue")).toBeInTheDocument();
+      });
     });
   });
 
-  it("keeps cursor in place when pressing left arrow at start of first filter", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
+  describe("Keyboard Navigation", () => {
+    it("allows keyboard navigation of suggestions", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Click the filter to edit it
-    const kindBadgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(kindBadgeRoot);
+      await act(async () => {
+        await userEvent.type(searchInput, "k");
+      });
 
-    // Move cursor to start of input
-    const kindInput = within(kindBadgeRoot).getByRole(
-      "textbox",
-    ) as HTMLInputElement;
-    await act(async () => {
-      fireEvent.change(kindInput, {
-        target: {
-          selectionEnd: 0,
-          selectionStart: 0,
-          value: "batch,",
-        },
+      await waitFor(() => {
+        expect(screen.getByTestId("suggestion-kind")).toBeInTheDocument();
+      });
+
+      // Press down arrow to highlight first suggestion
+      await act(async () => {
+        fireEvent.keyDown(searchInput, { key: "ArrowDown" });
+      });
+
+      // Press enter to select highlighted suggestion
+      await act(async () => {
+        fireEvent.keyDown(searchInput, { key: "Enter" });
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("kind:");
       });
     });
 
-    // Press Left Arrow (should stay in place as it's the first filter)
-    await act(async () => {
-      fireEvent.keyDown(kindInput, { key: "ArrowLeft" });
-    });
+    it("escapes to clear suggestions and input", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Verify input remains focused without checking cursor position
-    // as the exact cursor position may vary between implementations
-    await waitFor(() => {
-      expect(document.activeElement).toBe(kindInput);
-    });
-  });
+      await act(async () => {
+        await userEvent.type(searchInput, "kind");
+      });
 
-  it("focuses 'Add filter' input when pressing right arrow at end of last filter", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
+      await waitFor(() => {
+        expect(screen.getByTestId("suggestion-kind")).toBeInTheDocument();
+      });
 
-    // Click the filter to edit it
-    const kindBadgeRoot = getBadgeRootByTypeId("kind");
-    fireEvent.click(kindBadgeRoot);
+      // First escape closes suggestions
+      await act(async () => {
+        fireEvent.keyDown(searchInput, { key: "Escape" });
+      });
 
-    // Verify cursor is at the end of 'batch,'
-    const kindInput = within(kindBadgeRoot).getByRole(
-      "textbox",
-    ) as HTMLInputElement;
-    await waitFor(() => {
-      expect(kindInput.getAttribute("value")).toBe("batch,");
-      expect(kindInput.selectionStart).toBe(6); // After the comma
-      expect(kindInput.selectionEnd).toBe(6);
-    });
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("suggestions-dropdown"),
+        ).not.toBeInTheDocument();
+      });
 
-    // Press Right Arrow (should focus the "Add filter" input since it's the last filter)
-    await act(async () => {
-      fireEvent.keyDown(kindInput, { key: "ArrowRight" });
-    });
+      // Second escape clears input
+      await act(async () => {
+        fireEvent.keyDown(searchInput, { key: "Escape" });
+      });
 
-    // Verify the "Add filter" input is now focused
-    await waitFor(() => {
-      const addFilterInput = screen.getByTestId("job-search-input");
-      expect(document.activeElement).toBe(addFilterInput);
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("");
+      });
     });
   });
 
-  it("focuses last filter when pressing left arrow at start of 'Add filter' input", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-      {
-        id: "2",
-        prefix: "queue:",
-        typeId: FilterTypeId.QUEUE,
-        values: ["default"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
+  describe("Filter Management", () => {
+    it("allows adding multiple values to a filter", async () => {
+      const onFiltersChange = vi.fn();
+      render(<JobSearch onFiltersChange={onFiltersChange} />);
 
-    // Focus the "Add filter" input
-    const addFilterInput = screen.getByTestId("job-search-input");
-    await act(async () => {
-      addFilterInput.focus();
-    });
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Verify "Add filter" input is focused
-    expect(document.activeElement).toBe(addFilterInput);
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch,stream");
+      });
 
-    // Press Left Arrow at the beginning of the input
-    await act(async () => {
-      fireEvent.keyDown(addFilterInput, { key: "ArrowLeft" });
-    });
-
-    // Verify focus moves to the last filter (queue)
-    await waitFor(() => {
-      const queueBadgeRoot = getBadgeRootByTypeId("queue");
-      const queueInput = within(queueBadgeRoot).getByRole("textbox");
-      expect(document.activeElement).toBe(queueInput);
-    });
-  });
-
-  it("selects first suggestion when pressing Enter with characters typed but no suggestion highlighted", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: [],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
-
-    // Click the filter to edit it
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    await act(async () => {
-      fireEvent.click(badgeRoot);
-    });
-
-    // First, verify that pressing Enter without typing anything doesn't select first suggestion
-    const input = within(badgeRoot).getByRole("textbox");
-
-    // Wait for suggestions to appear (empty input shows all suggestions)
-    await waitFor(() => {
-      expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-    });
-
-    // Press Enter with empty input
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-    });
-
-    // Verify no suggestion was selected, edit mode should end
-    await waitFor(() => {
-      const updatedBadge = getBadgeRootByTypeId("kind");
-      expect(updatedBadge).not.toHaveClass("ring-2"); // No longer in edit mode
-    });
-
-    // Click again to restart edit mode
-    await act(async () => {
-      fireEvent.click(badgeRoot);
-    });
-
-    // Now type to trigger suggestions
-    await userEvent.type(input, "b");
-
-    // Wait for suggestions
-    await waitFor(() => {
-      const dropdown = screen.getByTestId("suggestions-dropdown");
-      expect(dropdown).toBeInTheDocument();
-    });
-
-    // Verify we have suggestions but none are highlighted
-    await waitFor(() => {
-      const suggestionsList = screen.getByTestId("suggestions-list");
-      const suggestionButtons = within(suggestionsList).getAllByRole("button");
-      expect(suggestionButtons.length).toBeGreaterThan(0);
-
-      // None of the buttons should have the highlight class
-      suggestionButtons.forEach((button) => {
-        expect(button).not.toHaveClass("bg-gray-100 dark:bg-gray-700");
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith([
+          expect.objectContaining({
+            prefix: "kind:",
+            typeId: FilterTypeId.KIND,
+            values: ["batch", "stream"],
+          }),
+        ]);
       });
     });
 
-    // Press Enter to select the first suggestion without any highlighting but with text typed
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-    });
+    it("allows adding multiple different filter types", async () => {
+      const onFiltersChange = vi.fn();
+      render(<JobSearch onFiltersChange={onFiltersChange} />);
 
-    // Verify the first suggestion was selected - should be "batch" based on the mock
-    await waitFor(() => {
-      const updatedInput = within(badgeRoot).getByRole("textbox");
-      expect(updatedInput.getAttribute("value")).toBe("batch");
-    });
-  });
+      const searchInput = screen.getByTestId("job-search-input");
 
-  it("focuses previous filter when deleting a filter with backspace", async () => {
-    const initialFilters: Filter[] = [
-      {
-        id: "1",
-        prefix: "kind:",
-        typeId: FilterTypeId.KIND,
-        values: ["batch"],
-      },
-      {
-        id: "2",
-        prefix: "queue:",
-        typeId: FilterTypeId.QUEUE,
-        values: ["default"],
-      },
-    ];
-    render(<JobSearch initialFilters={initialFilters} />);
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch queue:priority");
+      });
 
-    // Click the second filter to edit it
-    const queueBadgeRoot = getBadgeRootByTypeId("queue");
-    fireEvent.click(queueBadgeRoot);
-
-    // Clear the input
-    const queueInput = within(queueBadgeRoot).getByRole("textbox");
-    await act(async () => {
-      fireEvent.change(queueInput, {
-        target: {
-          value: "",
-        },
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith([
+          expect.objectContaining({
+            prefix: "kind:",
+            typeId: FilterTypeId.KIND,
+            values: ["batch"],
+          }),
+          expect.objectContaining({
+            prefix: "queue:",
+            typeId: FilterTypeId.QUEUE,
+            values: ["priority"],
+          }),
+        ]);
       });
     });
 
-    // Press Backspace when input is empty to remove the filter
-    await act(async () => {
-      fireEvent.keyDown(queueInput, { key: "Backspace" });
+    it("handles spaces around filter expressions", async () => {
+      const onFiltersChange = vi.fn();
+      render(<JobSearch onFiltersChange={onFiltersChange} />);
+
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "  kind:batch   queue:priority  ");
+      });
+
+      await waitFor(() => {
+        expect(onFiltersChange).toHaveBeenCalledWith([
+          expect.objectContaining({
+            prefix: "kind:",
+            typeId: FilterTypeId.KIND,
+            values: ["batch"],
+          }),
+          expect.objectContaining({
+            prefix: "queue:",
+            typeId: FilterTypeId.QUEUE,
+            values: ["priority"],
+          }),
+        ]);
+      });
     });
-
-    // Verify the second filter is removed
-    expect(screen.queryByTestId("filter-badge-queue")).not.toBeInTheDocument();
-
-    // Verify focus has moved to the previous (first) filter
-    const kindBadgeRoot = getBadgeRootByTypeId("kind");
-    const kindInput = within(kindBadgeRoot).getByRole(
-      "textbox",
-    ) as HTMLInputElement;
-    expect(document.activeElement).toBe(kindInput);
-
-    // Verify the previous filter is in edit mode
-    expect(kindBadgeRoot).toHaveClass("ring-2"); // Checking for edit mode styling
-
-    // Cursor should be at the end of the value
-    expect(kindInput.selectionStart).toBe(kindInput.value.length);
   });
 
-  it("after selecting a suggestion with Enter, or editing a filter with no suggestions, pressing Enter again completes the filter and focuses the Add filter input (generalized)", async () => {
-    render(<JobSearch />);
+  describe("Filter Consolidation", () => {
+    it("consolidates duplicate filter types on blur", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
 
-    // Case 1: After selecting a suggestion
-    await selectFilterType("kind");
-    const badgeRoot = getBadgeRootByTypeId("kind");
-    const input = within(badgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(input);
-    await waitFor(() => {
-      expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-      expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
-    });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-    });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-    });
-    await waitFor(() => {
-      expect(document.activeElement).toBe(input);
-      expect(input.getAttribute("value")).not.toBe("");
-    });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: "Enter" });
-    });
-    await waitFor(() => {
-      const addFilterInput = screen.getByTestId("job-search-input");
-      expect(document.activeElement).toBe(addFilterInput);
-    });
-    // Verify filter type suggestions dropdown appears when add filter input is focused
-    await waitFor(() => {
-      expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-      expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
+      await act(async () => {
+        await userEvent.type(
+          searchInput,
+          "kind:AITrainingBatch,AnalyzeTextCorpus kind:Chaos priority:2",
+        );
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for the setTimeout in onBlur to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe(
+          "kind:AITrainingBatch,AnalyzeTextCorpus,Chaos priority:2",
+        );
+      });
     });
 
-    // Case 2: Editing a filter with no suggestions (ID)
-    await selectFilterType("id");
-    const idBadgeRoot = getBadgeRootByTypeId("id");
-    const idInput = within(idBadgeRoot).getByRole("textbox");
-    expect(document.activeElement).toBe(idInput);
-    // Type a value (no suggestions should appear)
-    await userEvent.type(idInput, "123");
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("suggestions-dropdown"),
-      ).not.toBeInTheDocument();
+    it("sorts values within consolidated filters", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:zebra kind:alpha kind:batch");
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for the setTimeout in onBlur to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe(
+          "kind:alpha,batch,zebra",
+        );
+      });
     });
-    // Press Enter to complete the filter
-    await act(async () => {
-      fireEvent.keyDown(idInput, { key: "Enter" });
+
+    it("preserves order of first appearance of filter types during consolidation", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(
+          searchInput,
+          "queue:high kind:batch queue:low priority:1",
+        );
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for the setTimeout in onBlur to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe(
+          "queue:high,low kind:batch priority:1",
+        );
+      });
     });
-    // Focus should move to Add filter input
-    await waitFor(() => {
-      const addFilterInput = screen.getByTestId("job-search-input");
-      expect(document.activeElement).toBe(addFilterInput);
+
+    it("removes duplicate values within the same filter type during consolidation", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch,stream kind:batch");
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for the setTimeout in onBlur to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("kind:batch,stream");
+      });
     });
-    // Verify filter type suggestions dropdown appears after focusing Add filter input
-    await waitFor(() => {
-      expect(screen.getByTestId("suggestions-dropdown")).toBeInTheDocument();
-      expect(screen.getByTestId("suggestions-list")).toBeInTheDocument();
+
+    it("does not consolidate when input has no duplicate filter types", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+      const originalValue = "kind:batch queue:priority";
+
+      await act(async () => {
+        await userEvent.type(searchInput, originalValue);
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for the setTimeout in onBlur to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe(originalValue);
+      });
+    });
+
+    it("preserves trailing whitespace on blur", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "kind:batch "); // note trailing space
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for consolidation logic to finish
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("kind:batch ");
+      });
+    });
+  });
+
+  describe("Input Validation", () => {
+    it("clears invalid filter type text on blur", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(searchInput, "invalidfilter");
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for the setTimeout in onBlur to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe("");
+      });
+    });
+
+    it("handles mixed valid and invalid input", async () => {
+      render(<JobSearch />);
+      const searchInput = screen.getByTestId("job-search-input");
+
+      await act(async () => {
+        await userEvent.type(
+          searchInput,
+          "kind:batch invalidtext queue:priority",
+        );
+      });
+
+      await act(async () => {
+        fireEvent.blur(searchInput);
+      });
+
+      // Wait for the setTimeout in onBlur to complete
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+
+      // Should keep valid filters and remove invalid text
+      await waitFor(() => {
+        expect(searchInput.getAttribute("value")).toBe(
+          "kind:batch queue:priority",
+        );
+      });
     });
   });
 });

--- a/src/components/job-search/JobSearch.tsx
+++ b/src/components/job-search/JobSearch.tsx
@@ -1,23 +1,13 @@
 import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/16/solid";
 import clsx from "clsx";
-import {
-  Dispatch,
-  KeyboardEvent,
-  useCallback,
-  useEffect,
-  useReducer,
-  useRef,
-  useState,
-} from "react";
+import { useRef } from "react";
 
 import { fetchSuggestions as defaultFetchSuggestions } from "./api";
-import { EditableBadge } from "./EditableBadge";
-import {
-  AVAILABLE_FILTERS,
-  FilterType,
-  JobFilter,
-  JobFilterTypeID,
-} from "./types";
+import { SuggestionsDropdown } from "./components/SuggestionsDropdown";
+import { useClickOutside } from "./components/useClickOutside";
+import { useKeyboardNavigation } from "./components/useKeyboardNavigation";
+import { useFilterInput } from "./hooks";
+import { FilterType, JobFilter, JobFilterTypeID } from "./types";
 
 export type { JobFilter as Filter, FilterType };
 export { JobFilterTypeID as FilterTypeId };
@@ -51,1048 +41,108 @@ export interface JobSearchProps {
   onFiltersChange?: (filters: JobFilter[]) => void;
 }
 
-// Type for actions that can be dispatched to the reducer
-type JobSearchAction =
-  | {
-      payload: { cursorPos: null | number; value: string };
-      type: "SET_RAW_EDITING_VALUE";
-    }
-  | {
-      payload: {
-        cursorPosition?: "end" | "start" | number;
-        filterId: string;
-      };
-      type: "START_EDITING_FILTER";
-    }
-  | { payload: { id: string; index: number }; type: "REMOVE_FILTER" }
-  | { payload: { id: string; values: string[] }; type: "UPDATE_FILTER_VALUES" }
-  | { payload: { index: number; value: string }; type: "SET_EDITING_VALUE" }
-  | { payload: boolean; type: "SET_LOADING_SUGGESTIONS" }
-  | { payload: boolean; type: "TOGGLE_FILTER_DROPDOWN" }
-  | { payload: FilterType; type: "ADD_FILTER" }
-  | { payload: JobFilter; type: "EDIT_FILTER" }
-  | { payload: number; type: "SET_HIGHLIGHTED_INDEX" }
-  | { payload: string; type: "SET_QUERY" }
-  | { payload: string[]; type: "SET_SUGGESTIONS" }
-  | { type: "ENTER_SUGGESTION_SELECTED_MODE" }
-  | { type: "ENTER_TYPING_MODE" }
-  | { type: "RESET_ALL" }
-  | { type: "STOP_EDITING_FILTER" };
-
-// Type for the state managed by the reducer
-interface JobSearchState {
-  editingFilter: {
-    editingCursorPos: null | number;
-    editingMode: "IDLE" | "SUGGESTION_SELECTED" | "TYPING";
-    editingValue: null | string;
-    filterId: null | string;
-    highlightedIndex: number;
-    isLoadingSuggestions: boolean;
-    showFilterDropdown: boolean;
-    suggestions: string[];
-  };
-  filters: JobFilter[];
-  query: string;
-}
-
-// Utility to finalize edit value
-const finalizeEditValue = (value: null | string): string[] => {
-  if (value === null) return [];
-  const uniq = Array.from(
-    new Set(
-      value
-        .split(",")
-        .map((v) => v.trim())
-        .filter(Boolean),
-    ),
-  );
-  return [...uniq].sort();
-};
-
-// Function to find the token index at a given cursor position
-const getTokenIndexAtCursor = (
-  value: string,
-  cursorPos: null | number,
-): number => {
-  // Handle cursor at or past the end first
-  if (cursorPos === null || cursorPos >= value.length) {
-    const parts = value.split(",");
-    return parts.length - 1; // Always the index of the last part (even if empty)
-  }
-
-  // If cursor is within the string, count preceding commas
-  // The number of commas before the cursor determines the token index
-  const commasBeforeCursor =
-    value.substring(0, cursorPos).match(/,/g)?.length ?? 0;
-  return commasBeforeCursor;
-};
-
-// Reducer function
-const jobSearchReducer = (
-  state: JobSearchState,
-  action: JobSearchAction,
-): JobSearchState => {
-  switch (action.type) {
-    case "ADD_FILTER": {
-      const existing = state.filters.find(
-        (f) => f.typeId === action.payload.id,
-      );
-      if (existing) {
-        // Start editing existing filter
-        const editingValue =
-          existing.values.join(",") + (existing.values.length > 0 ? "," : "");
-        return {
-          ...state,
-          editingFilter: {
-            ...state.editingFilter,
-            editingCursorPos: editingValue.length, // Default cursor to end
-            editingMode: "TYPING",
-            editingValue: editingValue,
-            filterId: existing.id,
-            isLoadingSuggestions: true, // Start loading suggestions
-            showFilterDropdown: false,
-            suggestions: [], // Clear suggestions initially
-          },
-          filters: state.filters, // Don't modify filters when editing existing
-        };
-      }
-
-      // Add new filter and start editing
-      const newFilter: JobFilter = {
-        id: Math.random().toString(36).substr(2, 9),
-        prefix: action.payload.prefix,
-        typeId: action.payload.id,
-        values: [],
-      };
-      const newFilters = [...state.filters, newFilter];
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          editingCursorPos: 0, // Start cursor at beginning for new filter
-          editingMode: "TYPING",
-          editingValue: "", // Start with empty value for new filter
-          filterId: newFilter.id,
-          isLoadingSuggestions: true, // Start loading suggestions
-          showFilterDropdown: false,
-          suggestions: [], // Clear suggestions initially
-        },
-        filters: newFilters,
-      };
-    }
-
-    case "EDIT_FILTER": {
-      const filterToEdit2 = state.filters.find(
-        (f) => f.id === action.payload.id,
-      );
-      if (!filterToEdit2) return state; // Should not happen
-      const editingValue2 =
-        action.payload.values.join(",") +
-        (action.payload.values.length > 0 ? "," : "");
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          editingCursorPos: editingValue2.length, // Default cursor to end
-          editingMode: "TYPING",
-          editingValue: editingValue2,
-          filterId: action.payload.id,
-          highlightedIndex: -1,
-          isLoadingSuggestions: true, // Start loading suggestions
-          showFilterDropdown: false,
-          suggestions: [],
-        },
-        filters: state.filters.map((filter) =>
-          filter.id === action.payload.id
-            ? { ...filter, values: action.payload.values }
-            : filter,
-        ),
-      };
-    }
-
-    case "ENTER_SUGGESTION_SELECTED_MODE":
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          editingMode: "SUGGESTION_SELECTED",
-        },
-      };
-
-    case "ENTER_TYPING_MODE":
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          editingMode: "TYPING",
-        },
-      };
-
-    case "REMOVE_FILTER": {
-      // If removing the filter being edited, stop editing
-      const filterBeingRemoved = action.payload.id;
-      const filterIndex = action.payload.index;
-      const stopEditing = state.editingFilter.filterId === filterBeingRemoved;
-
-      // Get the new filters array after removal
-      const newFilters = state.filters.filter(
-        (filter) => filter.id !== filterBeingRemoved,
-      );
-
-      // Determine if we should focus the previous filter
-      let focusPreviousFilter = false;
-      let previousFilterId: null | string = null;
-
-      if (stopEditing && filterIndex > 0 && newFilters.length > 0) {
-        // If removing the current filter and it's not the first one, focus the previous filter
-        focusPreviousFilter = true;
-        // Get the ID of the filter that will now be at index filterIndex-1
-        previousFilterId = newFilters[filterIndex - 1]?.id || null;
-      }
-
-      if (focusPreviousFilter && previousFilterId) {
-        // Find the previous filter
-        const previousFilter = newFilters.find(
-          (f) => f.id === previousFilterId,
-        );
-        if (previousFilter) {
-          // Create the editing value with trailing comma like START_EDITING_FILTER would do
-          const editingValue =
-            previousFilter.values.join(",") +
-            (previousFilter.values.length > 0 ? "," : "");
-
-          // Focus previous filter by starting to edit it (cursor at the end implicitly)
-          return {
-            ...state,
-            editingFilter: {
-              ...state.editingFilter,
-              editingCursorPos: editingValue.length, // Explicitly set cursor at the end
-              editingMode: "TYPING",
-              editingValue: editingValue, // Properly set the editing value
-              filterId: previousFilterId,
-              highlightedIndex: -1,
-              isLoadingSuggestions: true,
-              suggestions: [],
-            },
-            filters: newFilters,
-          };
-        }
-      }
-
-      // Original behavior - just remove the filter without focusing anywhere
-      return {
-        ...state,
-        editingFilter: stopEditing
-          ? {
-              // Reset editing state
-              ...state.editingFilter,
-              editingMode: "IDLE",
-              editingValue: null,
-              filterId: null,
-              highlightedIndex: -1,
-              isLoadingSuggestions: false,
-              suggestions: [],
-            }
-          : state.editingFilter,
-        filters: newFilters,
-      };
-    }
-
-    case "RESET_ALL":
-      return {
-        ...state,
-        editingFilter: {
-          // Reset editing state
-          ...state.editingFilter,
-          editingMode: "IDLE",
-          editingValue: null,
-          filterId: null,
-          highlightedIndex: -1,
-          isLoadingSuggestions: false,
-          showFilterDropdown: false,
-          suggestions: [],
-        },
-        filters: [],
-        query: "",
-      };
-
-    case "SET_HIGHLIGHTED_INDEX":
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          highlightedIndex: action.payload,
-        },
-      };
-
-    case "SET_LOADING_SUGGESTIONS":
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          isLoadingSuggestions: action.payload,
-        },
-      };
-
-    case "SET_QUERY":
-      return { ...state, query: action.payload };
-
-    case "SET_RAW_EDITING_VALUE":
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          editingCursorPos: action.payload.cursorPos,
-          editingValue: action.payload.value,
-        },
-      };
-
-    case "SET_SUGGESTIONS":
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          highlightedIndex: -1,
-          isLoadingSuggestions: false,
-          suggestions: action.payload,
-        },
-      };
-
-    case "START_EDITING_FILTER": {
-      const filterToEdit = state.filters.find(
-        (f) => f.id === action.payload.filterId,
-      );
-      if (!filterToEdit) return state; // Should not happen
-      const editingValue =
-        filterToEdit.values.join(",") +
-        (filterToEdit.values.length > 0 ? "," : "");
-
-      let targetCursorPos: null | number = null;
-      const position = action.payload.cursorPosition;
-
-      if (position === "start") {
-        targetCursorPos = 0;
-      } else if (position === "end" || position === undefined) {
-        targetCursorPos = editingValue.length; // Default to end
-      } else if (typeof position === "number") {
-        targetCursorPos = position;
-      } else {
-        targetCursorPos = editingValue.length; // Fallback to end
-      }
-
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          editingCursorPos: targetCursorPos, // Use calculated cursor position
-          editingMode: "TYPING",
-          editingValue: editingValue,
-          filterId: action.payload.filterId,
-          highlightedIndex: -1,
-          isLoadingSuggestions: true, // Start loading suggestions for the existing value
-          showFilterDropdown: false,
-          suggestions: [], // Clear suggestions initially
-        },
-      };
-    }
-
-    case "STOP_EDITING_FILTER": {
-      // Handle stopping edit mode for a filter
-      if (!state.editingFilter.filterId) return state; // Not editing
-      const finalizedValues = finalizeEditValue(
-        state.editingFilter.editingValue,
-      );
-      const filterIdToUpdate = state.editingFilter.filterId;
-      return {
-        ...state,
-        editingFilter: {
-          // Reset editing state
-          ...state.editingFilter,
-          editingMode: "IDLE",
-          editingValue: null,
-          filterId: null,
-          highlightedIndex: -1,
-          isLoadingSuggestions: false,
-          suggestions: [],
-        },
-        filters: state.filters.map((filter) =>
-          filter.id === filterIdToUpdate
-            ? { ...filter, values: finalizedValues }
-            : filter,
-        ),
-      };
-    }
-
-    case "TOGGLE_FILTER_DROPDOWN":
-      // Prevent opening if editing a filter
-      if (state.editingFilter.filterId) return state;
-      return {
-        ...state,
-        editingFilter: {
-          ...state.editingFilter,
-          showFilterDropdown: action.payload,
-        },
-      };
-
-    case "UPDATE_FILTER_VALUES": // Keep for potential external updates
-      return {
-        ...state,
-        filters: state.filters.map((filter) =>
-          filter.id === action.payload.id
-            ? { ...filter, values: action.payload.values }
-            : filter,
-        ),
-      };
-
-    default:
-      return state;
-  }
-};
-
-// Component for rendering the autocomplete suggestions dropdown
-const SuggestionsDropdown = ({
-  editingState,
-  handleSelectSuggestion,
-  setHighlightedIndex,
-}: {
-  editingState: {
-    editingValue: null | string;
-    filterId: null | string;
-    highlightedIndex: number;
-    isLoadingSuggestions: boolean;
-    showFilterDropdown: boolean;
-    suggestions: string[];
-  };
-  handleSelectSuggestion: (suggestion: string) => void;
-  setHighlightedIndex: (index: number) => void;
-}) => (
-  <div
-    className="absolute top-full right-0 left-0 z-10 mt-1 overflow-hidden rounded-md border border-gray-300 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
-    data-testid="suggestions-dropdown"
-  >
-    <div className="p-2">
-      <div className="space-y-1" data-testid="suggestions-list">
-        {editingState.isLoadingSuggestions && (
-          <div className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
-            Loading suggestions...
-          </div>
-        )}
-        {editingState.suggestions.length === 0 &&
-          !editingState.isLoadingSuggestions && (
-            <div className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
-              No suggestions found
-            </div>
-          )}
-        <div className="space-y-1">
-          {editingState.suggestions.map((suggestion: string, index: number) => (
-            <button
-              className={clsx(
-                "flex w-full items-center rounded-md px-2 py-1 text-left text-sm text-gray-900 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-700",
-                editingState.highlightedIndex >= 0 &&
-                  index === editingState.highlightedIndex &&
-                  "bg-gray-100 dark:bg-gray-700",
-              )}
-              data-testid={`suggestion-${suggestion}`}
-              key={suggestion}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                handleSelectSuggestion(suggestion);
-              }}
-              onMouseEnter={() => {
-                setHighlightedIndex(index);
-              }}
-            >
-              {suggestion}
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  </div>
-);
-
-// Utility function to handle keyboard navigation for suggestions
-const handleSuggestionKeyDown = (
-  e: KeyboardEvent,
-  editingState: {
-    editingValue: null | string;
-    filterId: null | string;
-    highlightedIndex: number;
-    isLoadingSuggestions: boolean;
-    showFilterDropdown: boolean;
-    suggestions: string[];
-  },
-  dispatch: Dispatch<JobSearchAction>,
-  handleSelectSuggestion: (suggestion: string) => void,
-) => {
-  if (editingState.suggestions.length === 0) return false;
-
-  if (e.key === "ArrowDown") {
-    e.preventDefault();
-    const newIndex =
-      editingState.highlightedIndex === -1
-        ? 0
-        : (editingState.highlightedIndex + 1) % editingState.suggestions.length;
-    dispatch({
-      payload: newIndex,
-      type: "SET_HIGHLIGHTED_INDEX",
-    });
-    return true;
-  } else if (e.key === "ArrowUp") {
-    e.preventDefault();
-    const newIndex =
-      editingState.highlightedIndex === -1
-        ? editingState.suggestions.length - 1
-        : (editingState.highlightedIndex -
-            1 +
-            editingState.suggestions.length) %
-          editingState.suggestions.length;
-    dispatch({
-      payload: newIndex,
-      type: "SET_HIGHLIGHTED_INDEX",
-    });
-    return true;
-  } else if (e.key === "Enter") {
-    if (
-      editingState.highlightedIndex >= 0 &&
-      editingState.highlightedIndex < editingState.suggestions.length
-    ) {
-      // A suggestion is specifically highlighted, select it
-      e.preventDefault();
-      handleSelectSuggestion(
-        editingState.suggestions[editingState.highlightedIndex],
-      );
-      return true;
-    } else if (
-      editingState.suggestions.length > 0 &&
-      editingState.editingValue !== null
-    ) {
-      // Get the token at cursor position
-      const input = e.target as HTMLInputElement;
-      const cursorPos = input.selectionStart || 0;
-      const value = editingState.editingValue;
-
-      // Find the token at cursor position
-      const tokens = value.split(",");
-      let currentIndex = 0;
-      let tokenIndex = -1;
-
-      // Determine which token the cursor is in
-      for (let i = 0; i < tokens.length; i++) {
-        const token = tokens[i];
-        currentIndex += token.length;
-
-        if (cursorPos <= currentIndex) {
-          tokenIndex = i;
-          break;
-        }
-
-        // Add 1 for the comma
-        currentIndex += 1;
-
-        if (cursorPos <= currentIndex) {
-          // Cursor is right after a comma, this is the next token
-          tokenIndex = i + 1;
-          break;
-        }
-      }
-
-      // If we didn't find it, it's the last token
-      if (tokenIndex === -1) {
-        tokenIndex = tokens.length - 1;
-      }
-
-      // Get the current token
-      const currentToken = tokens[tokenIndex] ? tokens[tokenIndex].trim() : "";
-
-      // Only auto-select if the current token has content
-      if (currentToken !== "") {
-        e.preventDefault();
-        handleSelectSuggestion(editingState.suggestions[0]);
-        return true;
-      }
-    }
-  }
-  return false;
-};
-
 export function JobSearch({
   className,
   fetchSuggestions = defaultFetchSuggestions,
   initialFilters = [],
   onFiltersChange,
 }: JobSearchProps) {
-  // Initialize the state with reducer
-  const [state, dispatch] = useReducer(jobSearchReducer, {
-    editingFilter: {
-      editingCursorPos: null,
-      editingMode: "IDLE",
-      editingValue: null,
-      filterId: null,
-      highlightedIndex: -1,
-      isLoadingSuggestions: false,
-      showFilterDropdown: false,
-      suggestions: [],
-    },
-    filters: initialFilters,
-    query: "",
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const {
+    clearSuggestions,
+    cursorPosition,
+    handleBlur,
+    handleClearAll,
+    handleColonShortcut,
+    handleInputChange,
+    handleSelectSuggestion,
+    inputValue,
+    setCursorPosition,
+    setHighlightedIndex,
+    suggestionsState,
+    updateSuggestions,
+  } = useFilterInput({
+    fetchSuggestions,
+    initialFilters,
+    onFiltersChange,
   });
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [filterTypeSuggestions, setFilterTypeSuggestions] = useState<
-    FilterType[]
-  >([]);
-  const [filterTypeDropdownOpen, setFilterTypeDropdownOpen] = useState(false);
-  const [filterTypeHighlightedIndex, setFilterTypeHighlightedIndex] =
-    useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
+  // Handle clicking outside to close suggestions
+  useClickOutside(containerRef, clearSuggestions);
 
-  // Handle clicking outside to close dropdowns
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        dispatch({ payload: false, type: "TOGGLE_FILTER_DROPDOWN" });
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  // Handle input change from React event
+  const handleInputChangeEvent = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    const newCursor = e.target.selectionStart || 0;
 
-  // Notify parent when filters change
-  useEffect(() => {
-    onFiltersChange?.(state.filters);
-  }, [state.filters, onFiltersChange]);
-
-  // Notify parent when editing filter values change
-  useEffect(() => {
-    if (
-      state.editingFilter.filterId &&
-      state.editingFilter.editingValue !== null
-    ) {
-      const finalizedValues = finalizeEditValue(
-        state.editingFilter.editingValue,
-      );
-      const updatedFilters = state.filters.map((filter) =>
-        filter.id === state.editingFilter.filterId
-          ? { ...filter, values: finalizedValues }
-          : filter,
-      );
-      onFiltersChange?.(updatedFilters);
+    // Check for colon shortcut
+    const shortcutFilter = handleColonShortcut(newValue, inputValue.length);
+    if (shortcutFilter) {
+      handleSuggestionSelect(shortcutFilter);
+      return;
     }
-  }, [
-    state.editingFilter.editingValue,
-    state.editingFilter.filterId,
-    state.filters,
-    onFiltersChange,
-  ]);
 
-  // Add handler for focusing the Add filter input
-  const handleFocusAddFilterInput = useCallback(() => {
+    handleInputChange(newValue, newCursor);
+  };
+
+  // Handle cursor position changes
+  const handleSelectionChange = () => {
     if (inputRef.current) {
-      // First make sure we're not in edit mode
-      dispatch({ type: "STOP_EDITING_FILTER" });
-      // Update filter type suggestions for Add filter input
-      const q = state.query.trim().toLowerCase();
-      const filtered = AVAILABLE_FILTERS.filter(
-        (f) =>
-          f.label.toLowerCase().includes(q) ||
-          f.prefix.toLowerCase().startsWith(q),
-      );
-      setFilterTypeSuggestions(filtered);
-      setFilterTypeDropdownOpen(true);
-      setFilterTypeHighlightedIndex(0);
-      // Then focus the Add filter input
+      const newCursor = inputRef.current.selectionStart || 0;
+      setCursorPosition(newCursor);
+      updateSuggestions(inputValue, newCursor);
+    }
+  };
+
+  // Handle focus to show suggestions
+  const handleFocus = () => {
+    updateSuggestions(inputValue, cursorPosition);
+  };
+
+  // Handle suggestion selection with input focus management
+  const handleSuggestionSelect = (suggestion: string) => {
+    const result = handleSelectSuggestion(suggestion);
+
+    // Focus input and set cursor position
+    if (inputRef.current) {
       inputRef.current.focus();
-    }
-  }, [dispatch, state.query]);
-
-  // Handles raw value change from EditableBadge input
-  const handleRawValueChange = useCallback(
-    async (newValue: string, cursorPos: null | number) => {
-      // Update the raw editing value and cursor position in state immediately
-      dispatch({
-        payload: { cursorPos, value: newValue },
-        type: "SET_RAW_EDITING_VALUE",
-      });
-
-      const currentFilterId = state.editingFilter.filterId;
-      if (!currentFilterId) return; // Not editing a filter
-
-      const currentFilter = state.filters.find((f) => f.id === currentFilterId);
-      if (!currentFilter) return;
-
-      // Disable autocomplete for Job ID filter
-      if (currentFilter.typeId === JobFilterTypeID.ID) {
-        dispatch({ payload: [], type: "SET_SUGGESTIONS" });
-        return;
-      }
-
-      // Determine the token being edited based on cursor position
-      const tokenIndex = getTokenIndexAtCursor(newValue, cursorPos);
-      const parts = newValue.split(",");
-      const currentToken = parts[tokenIndex]?.trim() ?? "";
-
-      // Generate exclusion list based on *all* tokens (not just others)
-      const existingTokens = parts.map((s) => s.trim()).filter(Boolean);
-
-      // Transition back to TYPING mode if the user edits the input after selection
-      if (
-        state.editingFilter.editingMode === "SUGGESTION_SELECTED" &&
-        newValue !== state.editingFilter.editingValue
-      ) {
-        dispatch({ type: "ENTER_TYPING_MODE" });
-      }
-
-      // Determine if we should fetch suggestions based on editing mode
-      const shouldFetch =
-        (state.editingFilter.editingMode === "TYPING" ||
-          (state.editingFilter.editingMode === "SUGGESTION_SELECTED" &&
-            newValue !== state.editingFilter.editingValue)) &&
-        // Fetch suggestions for the current token or if ready for a new value
-        (currentToken !== "" ||
-          parts[tokenIndex] === "" ||
-          newValue.endsWith(",") ||
-          newValue === "");
-
-      if (shouldFetch) {
-        dispatch({ payload: true, type: "SET_LOADING_SUGGESTIONS" });
-        try {
-          const newSuggestions = await fetchSuggestions(
-            currentFilter.typeId,
-            currentToken, // Fetch based on the current token at cursor position
-            existingTokens,
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.setSelectionRange(
+            result.newCursorPos,
+            result.newCursorPos,
           );
-          // Only update if still editing the same filter
-          if (state.editingFilter.filterId === currentFilterId) {
-            dispatch({ payload: newSuggestions, type: "SET_SUGGESTIONS" });
-          }
-        } catch (_error) {
-          if (state.editingFilter.filterId === currentFilterId) {
-            dispatch({ payload: [], type: "SET_SUGGESTIONS" });
+          // If we just applied a filter type, immediately show value suggestions
+          if (result.shouldShowValueSuggestions) {
+            updateSuggestions(result.newText, result.newCursorPos);
           }
         }
-        // No finally needed as SET_SUGGESTIONS handles loading state
-      } else {
-        // Clear suggestions if not fetching
-        dispatch({ payload: [], type: "SET_SUGGESTIONS" });
-      }
-    },
-    [
-      dispatch,
-      state.filters, // Need filters to get typeId
-      state.editingFilter.filterId, // Need filterId to check if still editing
-      state.editingFilter.editingMode, // Depend on editing mode
-      state.editingFilter.editingValue, // Added to resolve ESLint warning
-      fetchSuggestions,
-    ],
-  );
-
-  // Fetch initial suggestions when editing starts
-  useEffect(() => {
-    const currentFilterId = state.editingFilter.filterId;
-    if (currentFilterId && state.editingFilter.editingValue !== null) {
-      // Call handleRawValueChange to trigger fetch for the current editing value
-      handleRawValueChange(
-        state.editingFilter.editingValue,
-        state.editingFilter.editingCursorPos,
-      );
-    }
-  }, [
-    state.editingFilter.filterId,
-    state.editingFilter.editingValue,
-    state.editingFilter.editingCursorPos,
-    handleRawValueChange,
-  ]);
-
-  // Handle selecting a suggestion
-  const handleSelectSuggestion = (suggestion: string) => {
-    // Calculate the new value based on current state
-    const currentValue = state.editingFilter.editingValue ?? "";
-    const cursorPos = state.editingFilter.editingCursorPos;
-    const tokenIndex = getTokenIndexAtCursor(currentValue, cursorPos);
-    const parts = currentValue.split(",");
-
-    if (tokenIndex < 0 || tokenIndex >= parts.length) {
-      // Log the values to understand why index might be invalid
-      console.warn("handleSelectSuggestion: Invalid token index", {
-        currentValue,
-        cursorPos,
-        parts, // Add parts for debugging
-        tokenIndex,
-      });
-      return;
-    }
-
-    const trimmedSuggestion = suggestion.trim();
-
-    // --- Revised token replacement logic ---
-    // Create a new array of parts
-    const newParts = [...parts];
-
-    // Replace the token at the calculated index
-    newParts[tokenIndex] = trimmedSuggestion;
-
-    // Join the parts back together
-    const newValue = newParts.join(",");
-
-    // Calculate new cursor position after the replaced token
-    let newCursorPos = 0;
-    for (let i = 0; i <= tokenIndex; i++) {
-      newCursorPos += newParts[i].length;
-      if (i < tokenIndex) {
-        newCursorPos++; // Add 1 for the comma
-      }
-    }
-    // --- End revised logic ---
-
-    // Directly dispatch state updates
-    dispatch({
-      payload: { cursorPos: newCursorPos, value: newValue },
-      type: "SET_RAW_EDITING_VALUE",
-    });
-    dispatch({ payload: [], type: "SET_SUGGESTIONS" }); // Clear suggestions
-    dispatch({ type: "ENTER_SUGGESTION_SELECTED_MODE" }); // Set mode to prevent immediate autocomplete
-  };
-
-  // Helper: filter AVAILABLE_FILTERS by query
-  const getFilteredFilterTypes = (query: string) => {
-    const q = query.trim().toLowerCase();
-    return AVAILABLE_FILTERS.filter(
-      (f) =>
-        f.label.toLowerCase().includes(q) ||
-        f.prefix.toLowerCase().startsWith(q),
-    );
-  };
-
-  // Helper: check if query matches a filter type + ':'
-  const getFilterTypeByColonShortcut = (query: string) => {
-    const q = query.trim().toLowerCase();
-    return AVAILABLE_FILTERS.find(
-      (f) => q === f.label.toLowerCase() + ":" || q === f.prefix.toLowerCase(),
-    );
-  };
-
-  // Handle input change for filter type selection
-  const handleFilterTypeInputChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    const value = e.target.value;
-    dispatch({ payload: value, type: "SET_QUERY" });
-    if (state.editingFilter.filterId) return; // Don't show filter type dropdown if editing a filter
-    if (value === "") {
-      setFilterTypeSuggestions([]);
-      setFilterTypeDropdownOpen(false);
-      setFilterTypeHighlightedIndex(0);
-      return;
-    }
-    // Colon shortcut
-    const colonMatch = getFilterTypeByColonShortcut(value);
-    if (colonMatch) {
-      dispatch({ payload: colonMatch, type: "ADD_FILTER" });
-      dispatch({ payload: "", type: "SET_QUERY" });
-      setFilterTypeSuggestions([]);
-      setFilterTypeDropdownOpen(false);
-      setFilterTypeHighlightedIndex(0);
-      return;
-    }
-    const filtered = getFilteredFilterTypes(value);
-    setFilterTypeSuggestions(filtered);
-    setFilterTypeDropdownOpen(true);
-    setFilterTypeHighlightedIndex(0);
-  };
-
-  // Handle keyboard navigation for filter type suggestions
-  const handleFilterTypeInputKeyDown = (
-    e: React.KeyboardEvent<HTMLInputElement>,
-  ) => {
-    if (!filterTypeDropdownOpen || filterTypeSuggestions.length === 0) return;
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setFilterTypeHighlightedIndex(
-        (prev) => (prev + 1) % filterTypeSuggestions.length,
-      );
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setFilterTypeHighlightedIndex(
-        (prev) =>
-          (prev - 1 + filterTypeSuggestions.length) %
-          filterTypeSuggestions.length,
-      );
-    } else if (e.key === "Enter") {
-      e.preventDefault();
-      const selected = filterTypeSuggestions[filterTypeHighlightedIndex];
-      if (selected) {
-        // Check if a filter with this typeId already exists to prevent duplicate dispatches
-        const existing = state.filters.find((f) => f.typeId === selected.id);
-        if (!existing) {
-          dispatch({ payload: selected, type: "ADD_FILTER" });
-        } else {
-          // If filter exists, start editing it
-          dispatch({
-            payload: { filterId: existing.id },
-            type: "START_EDITING_FILTER",
-          });
-        }
-        dispatch({ payload: "", type: "SET_QUERY" });
-        setFilterTypeSuggestions([]);
-        setFilterTypeDropdownOpen(false);
-        setFilterTypeHighlightedIndex(0);
-      }
-    } else if (e.key === "Escape") {
-      setFilterTypeSuggestions([]);
-      setFilterTypeDropdownOpen(false);
-      setFilterTypeHighlightedIndex(0);
-      dispatch({ payload: "", type: "SET_QUERY" });
-      inputRef.current?.blur();
+      }, 0);
     }
   };
 
-  // Handle blur event to clear input if no selection is made
-  const handleFilterTypeInputBlur = () => {
-    setFilterTypeSuggestions([]);
-    setFilterTypeDropdownOpen(false);
-    setFilterTypeHighlightedIndex(0);
-    dispatch({ payload: "", type: "SET_QUERY" });
-  };
+  // Keyboard navigation
+  const { handleKeyDown } = useKeyboardNavigation({
+    cursorPosition,
+    highlightedIndex: suggestionsState.highlightedIndex,
+    inputValue,
+    onClearAll: handleClearAll,
+    onClearSuggestions: clearSuggestions,
+    onHighlightChange: setHighlightedIndex,
+    onSelectSuggestion: handleSuggestionSelect,
+    suggestions: suggestionsState.suggestions,
+    suggestionsCount: suggestionsState.suggestions.length,
+  });
 
-  // Handle clicking a filter type suggestion
-  const handleSelectFilterTypeSuggestion = (suggestion: string) => {
-    const selected = filterTypeSuggestions.find(
-      (f) => f.label === suggestion || f.prefix === suggestion,
-    );
-    if (selected) {
-      // Check if a filter with this typeId already exists to prevent duplicate dispatches
-      const existing = state.filters.find((f) => f.typeId === selected.id);
-      if (!existing) {
-        dispatch({ payload: selected, type: "ADD_FILTER" });
-      } else {
-        // If filter exists, start editing it
-        dispatch({
-          payload: { filterId: existing.id },
-          type: "START_EDITING_FILTER",
-        });
-      }
-      dispatch({ payload: "", type: "SET_QUERY" });
-      setFilterTypeSuggestions([]);
-      setFilterTypeDropdownOpen(false);
-      setFilterTypeHighlightedIndex(0);
-    } else {
-      console.log("No matching filter type found for suggestion:", suggestion);
-    }
-  };
-
-  // Handle navigating between filters
-  const handleNavigatePreviousFilter = useCallback(
-    (_e: CustomEvent) => {
-      if (state.editingFilter.filterId) {
-        const currentIndex = state.filters.findIndex(
-          (f) => f.id === state.editingFilter.filterId,
-        );
-        if (currentIndex > 0) {
-          const previousFilter = state.filters[currentIndex - 1];
-          // Stop editing the current filter
-          dispatch({ type: "STOP_EDITING_FILTER" });
-          // Start editing the previous filter, cursor defaults to end
-          dispatch({
-            payload: { filterId: previousFilter.id }, // Implicitly 'end' cursor
-            type: "START_EDITING_FILTER",
-          });
-          // Remove timeout-based focus logic
-        } else {
-          // If at the first filter, keep cursor at position 0
-          const currentFilter = state.filters[currentIndex];
-          if (currentFilter) {
-            const input = document.querySelector(
-              `[data-testid="filter-badge-${currentFilter.typeId}"] input`,
-            ) as HTMLInputElement;
-            if (input && document.activeElement === input) {
-              input.setSelectionRange(0, 0);
-            }
-          }
-        }
-      }
-    },
-    [state.editingFilter.filterId, state.filters, dispatch],
-  );
-
-  const handleNavigateNextFilter = useCallback(
-    (_e: CustomEvent) => {
-      if (state.editingFilter.filterId) {
-        const currentIndex = state.filters.findIndex(
-          (f) => f.id === state.editingFilter.filterId,
-        );
-        if (currentIndex < state.filters.length - 1) {
-          const nextFilter = state.filters[currentIndex + 1];
-          // Stop editing the current filter
-          dispatch({ type: "STOP_EDITING_FILTER" });
-          // Start editing the next filter, explicitly setting cursor to start
-          dispatch({
-            payload: { cursorPosition: "start", filterId: nextFilter.id },
-            type: "START_EDITING_FILTER",
-          });
-          // Remove timeout-based focus logic
-        } else {
-          // If at the last filter, focus the "Add filter" input
-          handleFocusAddFilterInput();
-        }
-      }
-    },
-    [
-      state.editingFilter.filterId,
-      state.filters,
-      dispatch,
-      handleFocusAddFilterInput,
-    ],
-  );
-
-  // Add event listeners for custom navigation events
-  useEffect(() => {
-    const container = containerRef.current;
-    if (container) {
-      container.addEventListener(
-        "navigatePreviousFilter",
-        handleNavigatePreviousFilter as EventListener,
-      );
-      container.addEventListener(
-        "navigateNextFilter",
-        handleNavigateNextFilter as EventListener,
-      );
-      container.addEventListener(
-        "focusAddFilterInput",
-        handleFocusAddFilterInput as EventListener,
-      );
-    }
-    return () => {
-      if (container) {
-        container.removeEventListener(
-          "navigatePreviousFilter",
-          handleNavigatePreviousFilter as EventListener,
-        );
-        container.removeEventListener(
-          "navigateNextFilter",
-          handleNavigateNextFilter as EventListener,
-        );
-        container.removeEventListener(
-          "focusAddFilterInput",
-          handleFocusAddFilterInput as EventListener,
-        );
-      }
-    };
-  }, [
-    state.editingFilter.filterId,
-    state.filters,
-    handleNavigatePreviousFilter,
-    handleNavigateNextFilter,
-    handleFocusAddFilterInput,
-  ]);
+  const showSuggestions =
+    suggestionsState.suggestions.length > 0 || suggestionsState.isLoading;
 
   return (
     <div className={clsx("w-full", className)} ref={containerRef}>
       <div className="relative">
-        {/* Search input and filters container */}
+        {/* Search input container */}
         <div className="relative w-full rounded-md border border-slate-300 bg-white focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500 dark:border-slate-700 dark:bg-slate-900">
           <div className="flex w-full items-stretch">
             {/* Search Icon */}
@@ -1102,138 +152,36 @@ export function JobSearch({
                 className="size-5 shrink-0 text-gray-400"
               />
             </div>
-            {/* Filters and input */}
-            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 py-2">
-              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
-                {state.filters.map((filter, index) => (
-                  <div className="max-w-full flex-shrink" key={filter.id}>
-                    <EditableBadge
-                      color="zinc"
-                      content={filter.values}
-                      dataTestId={`filter-badge-${filter.typeId}`}
-                      desiredCursorPos={
-                        state.editingFilter.filterId === filter.id
-                          ? state.editingFilter.editingCursorPos
-                          : null
-                      }
-                      editing={{
-                        onComplete: (reason) => {
-                          // Stop editing current filter
-                          dispatch({ type: "STOP_EDITING_FILTER" });
-                          if (reason === "enter") {
-                            // Prepare and open filter type suggestions for Add filter input
-                            const q = state.query.trim().toLowerCase();
-                            const filtered = AVAILABLE_FILTERS.filter(
-                              (f) =>
-                                f.label.toLowerCase().includes(q) ||
-                                f.prefix.toLowerCase().startsWith(q),
-                            );
-                            setFilterTypeSuggestions(filtered);
-                            setFilterTypeDropdownOpen(true);
-                            setFilterTypeHighlightedIndex(0);
-                            // Focus the Add filter input
-                            inputRef.current?.focus();
-                          }
-                        },
-                        onStart: () => {
-                          dispatch({
-                            payload: { filterId: filter.id },
-                            type: "START_EDITING_FILTER",
-                          });
-                        },
-                      }}
-                      isEditing={state.editingFilter.filterId === filter.id}
-                      isFirstFilter={index === 0}
-                      isLastFilter={index === state.filters.length - 1}
-                      onContentChange={(values) =>
-                        dispatch({
-                          payload: { id: filter.id, values },
-                          type: "UPDATE_FILTER_VALUES",
-                        })
-                      }
-                      onRawValueChange={(newValue, cursorPos) =>
-                        handleRawValueChange(newValue, cursorPos)
-                      }
-                      onRemove={() =>
-                        dispatch({
-                          payload: { id: filter.id, index },
-                          type: "REMOVE_FILTER",
-                        })
-                      }
-                      prefix={filter.prefix}
-                      rawEditValue={
-                        state.editingFilter.filterId === filter.id
-                          ? (state.editingFilter.editingValue ?? "")
-                          : filter.values.join(",")
-                      }
-                      suggestions={{
-                        onKeyDown: (e) => {
-                          handleSuggestionKeyDown(
-                            e,
-                            state.editingFilter,
-                            dispatch,
-                            handleSelectSuggestion,
-                          );
-                        },
-                      }}
-                    />
-                  </div>
-                ))}
-                <input
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className="min-w-[80px] flex-1 border-none bg-transparent p-0 text-gray-900 placeholder:text-gray-400 focus:border-none focus:ring-0 dark:text-white"
-                  data-1p-ignore
-                  data-form-type="other"
-                  data-testid="job-search-input"
-                  onBlur={handleFilterTypeInputBlur}
-                  onChange={handleFilterTypeInputChange}
-                  onFocus={() => {
-                    if (!state.editingFilter.filterId) {
-                      setFilterTypeDropdownOpen(true);
-                      setFilterTypeSuggestions(
-                        getFilteredFilterTypes(state.query),
-                      );
-                      setFilterTypeHighlightedIndex(0);
-                    }
-                  }}
-                  onKeyDown={(e) => {
-                    handleFilterTypeInputKeyDown(e);
-                    // Handle left arrow navigation to the last filter
-                    if (e.key === "ArrowLeft" && state.filters.length > 0) {
-                      const input = e.target as HTMLInputElement;
-                      if (
-                        input.selectionStart === 0 &&
-                        input.selectionEnd === 0
-                      ) {
-                        e.preventDefault();
-                        // Find the last filter
-                        const lastFilter =
-                          state.filters[state.filters.length - 1];
-                        // Start editing it
-                        dispatch({
-                          payload: { filterId: lastFilter.id },
-                          type: "START_EDITING_FILTER",
-                        });
-                        // Focus will be set by the useEffect in EditableBadge
-                      }
-                    }
-                  }}
-                  placeholder="Add filter"
-                  ref={inputRef}
-                  spellCheck={false}
-                  type="text"
-                  value={state.query}
-                />
-              </div>
+
+            {/* Main input */}
+            <div className="flex min-w-0 flex-1 items-center py-2">
+              <input
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect="off"
+                className="min-w-0 flex-1 border-none bg-transparent p-0 text-gray-900 placeholder:text-gray-400 focus:border-none focus:ring-0 dark:text-white"
+                data-1p-ignore
+                data-form-type="other"
+                data-testid="job-search-input"
+                onBlur={handleBlur}
+                onChange={handleInputChangeEvent}
+                onFocus={handleFocus}
+                onKeyDown={handleKeyDown}
+                onSelect={handleSelectionChange}
+                placeholder="Add filter"
+                ref={inputRef}
+                spellCheck={false}
+                type="text"
+                value={inputValue}
+              />
             </div>
-            {/* X Icon */}
-            {(state.filters.length > 0 || state.query) && (
+
+            {/* Clear button */}
+            {inputValue && (
               <div className="flex items-center pr-3 pl-1">
                 <button
                   className="shrink-0 text-gray-400 hover:text-gray-500"
-                  onClick={() => dispatch({ type: "RESET_ALL" })}
+                  onClick={handleClearAll}
                   type="button"
                 >
                   <XMarkIcon aria-hidden="true" className="size-5" />
@@ -1243,36 +191,16 @@ export function JobSearch({
           </div>
         </div>
 
-        {/* SuggestionsDropdown for filter type selection */}
-        {filterTypeDropdownOpen &&
-          !state.editingFilter.filterId &&
-          filterTypeSuggestions.length > 0 && (
-            <SuggestionsDropdown
-              editingState={{
-                editingValue: state.query,
-                filterId: null,
-                highlightedIndex: filterTypeHighlightedIndex,
-                isLoadingSuggestions: false,
-                showFilterDropdown: filterTypeDropdownOpen,
-                suggestions: filterTypeSuggestions.map((f) => f.label),
-              }}
-              handleSelectSuggestion={handleSelectFilterTypeSuggestion}
-              setHighlightedIndex={setFilterTypeHighlightedIndex}
-            />
-          )}
-
-        {/* Autocomplete Dropdown for filter values (unchanged) */}
-        {state.editingFilter.editingValue !== null &&
-          !state.editingFilter.isLoadingSuggestions &&
-          state.editingFilter.suggestions.length > 0 && (
-            <SuggestionsDropdown
-              editingState={state.editingFilter}
-              handleSelectSuggestion={handleSelectSuggestion}
-              setHighlightedIndex={(index) =>
-                dispatch({ payload: index, type: "SET_HIGHLIGHTED_INDEX" })
-              }
-            />
-          )}
+        {/* Suggestions dropdown */}
+        {showSuggestions && (
+          <SuggestionsDropdown
+            highlightedIndex={suggestionsState.highlightedIndex}
+            isLoading={suggestionsState.isLoading}
+            onHighlightChange={setHighlightedIndex}
+            onSelectSuggestion={handleSuggestionSelect}
+            suggestions={suggestionsState.suggestions}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/job-search/components/SuggestionsDropdown.tsx
+++ b/src/components/job-search/components/SuggestionsDropdown.tsx
@@ -1,0 +1,66 @@
+import clsx from "clsx";
+
+interface SuggestionsDropdownProps {
+  highlightedIndex: number;
+  isLoading: boolean;
+  onHighlightChange: (index: number) => void;
+  onSelectSuggestion: (suggestion: string) => void;
+  suggestions: string[];
+}
+
+export function SuggestionsDropdown({
+  highlightedIndex,
+  isLoading,
+  onHighlightChange,
+  onSelectSuggestion,
+  suggestions,
+}: SuggestionsDropdownProps) {
+  if (!isLoading && suggestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute top-full right-0 left-0 z-10 mt-1 overflow-hidden rounded-md border border-gray-300 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      data-testid="suggestions-dropdown"
+    >
+      <div className="p-2">
+        <div className="space-y-1" data-testid="suggestions-list">
+          {isLoading && (
+            <div className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+              Loading suggestions...
+            </div>
+          )}
+          {suggestions.length === 0 && !isLoading && (
+            <div className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+              No suggestions found
+            </div>
+          )}
+          <div className="space-y-1">
+            {suggestions.map((suggestion: string, index: number) => (
+              <button
+                className={clsx(
+                  "flex w-full items-center rounded-md px-2 py-1 text-left text-sm text-gray-900 hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-700",
+                  highlightedIndex >= 0 &&
+                    index === highlightedIndex &&
+                    "bg-gray-100 dark:bg-gray-700",
+                )}
+                data-testid={`suggestion-${suggestion}`}
+                key={suggestion}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelectSuggestion(suggestion);
+                }}
+                onMouseEnter={() => {
+                  onHighlightChange(index);
+                }}
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/job-search/components/useClickOutside.ts
+++ b/src/components/job-search/components/useClickOutside.ts
@@ -1,0 +1,17 @@
+import { RefObject, useEffect } from "react";
+
+export function useClickOutside(
+  ref: RefObject<HTMLElement | null>,
+  onClickOutside: () => void,
+) {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClickOutside();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [ref, onClickOutside]);
+}

--- a/src/components/job-search/components/useKeyboardNavigation.ts
+++ b/src/components/job-search/components/useKeyboardNavigation.ts
@@ -1,0 +1,97 @@
+import { KeyboardEvent, useCallback } from "react";
+
+import { analyzeAutocompleteContext } from "../parser";
+
+interface UseKeyboardNavigationProps {
+  cursorPosition: number;
+  highlightedIndex: number;
+  inputValue: string;
+  onClearAll: () => void;
+  onClearSuggestions: () => void;
+  onHighlightChange: (index: number) => void;
+  onSelectSuggestion: (suggestion: string) => void;
+  suggestions: string[];
+  suggestionsCount: number;
+}
+
+export function useKeyboardNavigation({
+  cursorPosition,
+  highlightedIndex,
+  inputValue,
+  onClearAll,
+  onClearSuggestions,
+  onHighlightChange,
+  onSelectSuggestion,
+  suggestions,
+  suggestionsCount,
+}: UseKeyboardNavigationProps) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (suggestionsCount > 0) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          const newIndex =
+            highlightedIndex === -1
+              ? 0
+              : (highlightedIndex + 1) % suggestionsCount;
+          onHighlightChange(newIndex);
+          return;
+        }
+
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          const newIndex =
+            highlightedIndex === -1
+              ? suggestionsCount - 1
+              : (highlightedIndex - 1 + suggestionsCount) % suggestionsCount;
+          onHighlightChange(newIndex);
+          return;
+        }
+
+        if (e.key === "Enter") {
+          if (highlightedIndex >= 0 && highlightedIndex < suggestionsCount) {
+            e.preventDefault();
+            onSelectSuggestion(suggestions[highlightedIndex]);
+            return;
+          }
+
+          // Auto-select first suggestion if there's text being typed
+          const context = analyzeAutocompleteContext(
+            inputValue,
+            cursorPosition,
+          );
+          if (context.currentToken && context.currentToken.trim().length > 0) {
+            e.preventDefault();
+            onSelectSuggestion(suggestions[0]);
+            return;
+          }
+        }
+
+        if (e.key === "Escape") {
+          e.preventDefault();
+          onClearSuggestions();
+          return;
+        }
+      }
+
+      // Handle Escape to clear input when no suggestions are shown
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClearAll();
+      }
+    },
+    [
+      inputValue,
+      cursorPosition,
+      suggestionsCount,
+      highlightedIndex,
+      onHighlightChange,
+      onSelectSuggestion,
+      onClearSuggestions,
+      onClearAll,
+      suggestions,
+    ],
+  );
+
+  return { handleKeyDown };
+}

--- a/src/components/job-search/hooks.ts
+++ b/src/components/job-search/hooks.ts
@@ -1,0 +1,321 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  analyzeAutocompleteContext,
+  applySuggestion,
+  consolidateFiltersText,
+  parseFiltersFromText,
+  serializeFiltersToText,
+} from "./parser";
+import { AVAILABLE_FILTERS, JobFilter, JobFilterTypeID } from "./types";
+
+interface SuggestionsState {
+  highlightedIndex: number;
+  isLoading: boolean;
+  suggestions: string[];
+  type: "filter-type" | "filter-value" | "none";
+}
+
+interface UseFilterInputProps {
+  fetchSuggestions: (
+    filterTypeId: JobFilterTypeID,
+    query: string,
+    selectedValues: string[],
+  ) => Promise<string[]>;
+  initialFilters: JobFilter[];
+  onFiltersChange?: (filters: JobFilter[]) => void;
+}
+
+interface UseSuggestionsProps {
+  fetchSuggestions: (
+    filterTypeId: JobFilterTypeID,
+    query: string,
+    selectedValues: string[],
+  ) => Promise<string[]>;
+  suppressSuggestions: boolean;
+}
+
+export function useFilterInput({
+  fetchSuggestions,
+  initialFilters,
+  onFiltersChange,
+}: UseFilterInputProps) {
+  const initialText = serializeFiltersToText(initialFilters);
+  const [inputValue, setInputValue] = useState(initialText);
+  const [cursorPosition, setCursorPosition] = useState(inputValue.length);
+  const [suppressSuggestions, setSuppressSuggestions] = useState(false);
+  const [lastSuggestionApplication, setLastSuggestionApplication] = useState<{
+    cursorPos: number;
+    text: string;
+  } | null>(null);
+
+  const debounceTimeoutRef = useRef<number | undefined>(undefined);
+  const currentFilters = parseFiltersFromText(inputValue);
+
+  const {
+    clearSuggestions,
+    setHighlightedIndex,
+    suggestionsState,
+    updateSuggestions,
+  } = useSuggestions({ fetchSuggestions, suppressSuggestions });
+
+  // Debounced filter change notification
+  useEffect(() => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+    }
+
+    debounceTimeoutRef.current = window.setTimeout(() => {
+      onFiltersChange?.(currentFilters);
+    }, 200);
+
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, [currentFilters, onFiltersChange]);
+
+  const handleInputChange = useCallback(
+    (newValue: string, newCursor: number) => {
+      // Reset suppression if moved away from last application
+      if (
+        lastSuggestionApplication &&
+        (newValue !== lastSuggestionApplication.text ||
+          newCursor !== lastSuggestionApplication.cursorPos)
+      ) {
+        setSuppressSuggestions(false);
+        setLastSuggestionApplication(null);
+      }
+
+      setInputValue(newValue);
+      setCursorPosition(newCursor);
+      updateSuggestions(newValue, newCursor);
+    },
+    [lastSuggestionApplication, updateSuggestions],
+  );
+
+  // Handle colon shortcut separately to avoid circular dependency
+  const handleColonShortcut = useCallback(
+    (newValue: string, inputLength: number) => {
+      if (newValue.endsWith(":") && inputLength < newValue.length) {
+        const beforeColon = newValue.slice(0, -1).trim();
+        const words = beforeColon.split(/\s+/);
+        const lastWord = words[words.length - 1];
+        const filterType = AVAILABLE_FILTERS.find(
+          (f) => f.label.toLowerCase() === lastWord.toLowerCase(),
+        );
+        return filterType?.label;
+      }
+      return null;
+    },
+    [],
+  );
+
+  const handleSelectSuggestion = useCallback(
+    (suggestion: string) => {
+      const context = analyzeAutocompleteContext(inputValue, cursorPosition);
+      const result = applySuggestion(
+        inputValue,
+        cursorPosition,
+        suggestion,
+        context.type as "filter-type" | "filter-value",
+      );
+
+      setInputValue(result.newText);
+      setCursorPosition(result.newCursorPos);
+      clearSuggestions();
+
+      const shouldSuppress = context.type === "filter-value";
+      setSuppressSuggestions(shouldSuppress);
+      if (shouldSuppress) {
+        setLastSuggestionApplication({
+          cursorPos: result.newCursorPos,
+          text: result.newText,
+        });
+      }
+
+      return {
+        newCursorPos: result.newCursorPos,
+        newText: result.newText,
+        shouldShowValueSuggestions: context.type === "filter-type",
+      };
+    },
+    [inputValue, cursorPosition, clearSuggestions],
+  );
+
+  const handleClearAll = useCallback(() => {
+    setInputValue("");
+    setCursorPosition(0);
+    clearSuggestions();
+    setSuppressSuggestions(false);
+    setLastSuggestionApplication(null);
+  }, [clearSuggestions]);
+
+  const handleBlur = useCallback(() => {
+    clearSuggestions();
+
+    // Process input validation and consolidation
+    setTimeout(() => {
+      const trailingWhitespaceMatch = inputValue.match(/\s+$/);
+      const trailingWhitespace = trailingWhitespaceMatch
+        ? trailingWhitespaceMatch[0]
+        : "";
+      const trimmedValue = inputValue.trim();
+
+      // Clear invalid filter type text
+      if (trimmedValue && !trimmedValue.includes(":")) {
+        const isValidFilterType = AVAILABLE_FILTERS.some((f) =>
+          f.label.toLowerCase().includes(trimmedValue.toLowerCase()),
+        );
+        if (!isValidFilterType) {
+          setInputValue("");
+          setCursorPosition(0);
+          return;
+        }
+      }
+
+      // Consolidate filters
+      if (trimmedValue) {
+        const consolidated = consolidateFiltersText(trimmedValue);
+        const newText = consolidated + trailingWhitespace;
+        if (newText !== inputValue) {
+          setInputValue(newText);
+          setCursorPosition(newText.length);
+        }
+      }
+    }, 150);
+  }, [inputValue, clearSuggestions]);
+
+  return {
+    clearSuggestions,
+    cursorPosition,
+    handleBlur,
+    handleClearAll,
+    handleColonShortcut,
+    handleInputChange,
+    handleSelectSuggestion,
+    inputValue,
+    setCursorPosition,
+    setHighlightedIndex,
+    suggestionsState,
+    updateSuggestions,
+  };
+}
+
+export function useSuggestions({
+  fetchSuggestions,
+  suppressSuggestions,
+}: UseSuggestionsProps) {
+  const [suggestionsState, setSuggestionsState] = useState<SuggestionsState>({
+    highlightedIndex: -1,
+    isLoading: false,
+    suggestions: [],
+    type: "none",
+  });
+
+  const latestSuggestionRequestRef = useRef(0);
+
+  const updateSuggestions = useCallback(
+    async (text: string, cursor: number) => {
+      const requestId = ++latestSuggestionRequestRef.current;
+      const context = analyzeAutocompleteContext(
+        text,
+        cursor,
+        suppressSuggestions,
+      );
+
+      if (context.type === "none") {
+        setSuggestionsState((prev) => ({
+          ...prev,
+          isLoading: false,
+          suggestions: [],
+          type: "none",
+        }));
+        return;
+      }
+
+      // If we're suggesting filter types, we can compute synchronously and avoid the loading state
+      if (context.type === "filter-type") {
+        const query = context.currentToken || "";
+        const suggestions = AVAILABLE_FILTERS.filter(
+          (f) =>
+            f.label.toLowerCase().includes(query.toLowerCase()) ||
+            f.prefix.toLowerCase().startsWith(query.toLowerCase()),
+        ).map((f) => f.label);
+
+        setSuggestionsState((prev) => ({
+          ...prev,
+          highlightedIndex: -1,
+          isLoading: false,
+          suggestions,
+          type: "filter-type",
+        }));
+        return;
+      }
+
+      // For filter value suggestions we need to fetch asynchronously.
+      // Only show the loading indicator if we don't already have suggestions.
+      setSuggestionsState((prev) => ({
+        ...prev,
+        highlightedIndex: -1,
+        isLoading: prev.suggestions.length === 0,
+        type: context.type,
+      }));
+
+      try {
+        let suggestions: string[] = [];
+
+        if (context.type === "filter-value" && context.filterTypeId) {
+          suggestions = await fetchSuggestions(
+            context.filterTypeId,
+            context.currentToken || "",
+            context.existingValues || [],
+          );
+        }
+
+        if (requestId !== latestSuggestionRequestRef.current) {
+          return;
+        }
+
+        setSuggestionsState((prev) => ({
+          ...prev,
+          highlightedIndex: -1,
+          isLoading: false,
+          suggestions,
+        }));
+      } catch (_error) {
+        if (requestId !== latestSuggestionRequestRef.current) {
+          return;
+        }
+        setSuggestionsState((prev) => ({
+          ...prev,
+          highlightedIndex: -1,
+          isLoading: false,
+          suggestions: [],
+        }));
+      }
+    },
+    [fetchSuggestions, suppressSuggestions],
+  );
+
+  const clearSuggestions = useCallback(() => {
+    setSuggestionsState((prev) => ({
+      ...prev,
+      highlightedIndex: -1,
+      suggestions: [],
+      type: "none",
+    }));
+  }, []);
+
+  const setHighlightedIndex = useCallback((index: number) => {
+    setSuggestionsState((prev) => ({ ...prev, highlightedIndex: index }));
+  }, []);
+
+  return {
+    clearSuggestions,
+    setHighlightedIndex,
+    suggestionsState,
+    updateSuggestions,
+  };
+}

--- a/src/components/job-search/parser.test.ts
+++ b/src/components/job-search/parser.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeAutocompleteContext,
+  applySuggestion,
+  consolidateFiltersText,
+  parseFiltersFromText,
+  serializeFiltersToText,
+} from "./parser";
+import { JobFilterTypeID } from "./types";
+
+describe("parser", () => {
+  describe("parseFiltersFromText", () => {
+    it("parses simple filters", () => {
+      const result = parseFiltersFromText("kind:batch queue:priority");
+      expect(result).toHaveLength(2);
+      expect(result[0].prefix).toBe("kind:");
+      expect(result[0].values).toEqual(["batch"]);
+      expect(result[1].prefix).toBe("queue:");
+      expect(result[1].values).toEqual(["priority"]);
+    });
+
+    it("parses comma-separated values", () => {
+      const result = parseFiltersFromText("kind:batch,stream");
+      expect(result).toHaveLength(1);
+      expect(result[0].values).toEqual(["batch", "stream"]);
+    });
+
+    it("consolidates duplicate filter types", () => {
+      const result = parseFiltersFromText("kind:batch kind:stream");
+      expect(result).toHaveLength(1);
+      expect(result[0].values).toEqual(["batch", "stream"]);
+    });
+
+    it("sorts values within each filter", () => {
+      const result = parseFiltersFromText("kind:zebra,alpha,batch");
+      expect(result).toHaveLength(1);
+      expect(result[0].values).toEqual(["alpha", "batch", "zebra"]);
+    });
+
+    it("handles empty input", () => {
+      const result = parseFiltersFromText("");
+      expect(result).toHaveLength(0);
+    });
+
+    it("ignores invalid expressions", () => {
+      const result = parseFiltersFromText("invalid kind:batch");
+      expect(result).toHaveLength(1);
+      expect(result[0].prefix).toBe("kind:");
+    });
+  });
+
+  describe("serializeFiltersToText", () => {
+    it("serializes filters to text", () => {
+      const filters = [
+        {
+          id: "1",
+          prefix: "kind:",
+          typeId: JobFilterTypeID.KIND,
+          values: ["batch", "stream"],
+        },
+        {
+          id: "2",
+          prefix: "queue:",
+          typeId: JobFilterTypeID.QUEUE,
+          values: ["priority"],
+        },
+      ];
+      const result = serializeFiltersToText(filters);
+      expect(result).toBe("kind:batch,stream queue:priority");
+    });
+
+    it("skips filters with no values", () => {
+      const filters = [
+        {
+          id: "1",
+          prefix: "kind:",
+          typeId: JobFilterTypeID.KIND,
+          values: [],
+        },
+        {
+          id: "2",
+          prefix: "queue:",
+          typeId: JobFilterTypeID.QUEUE,
+          values: ["priority"],
+        },
+      ];
+      const result = serializeFiltersToText(filters);
+      expect(result).toBe("queue:priority");
+    });
+  });
+
+  describe("consolidateFiltersText", () => {
+    it("consolidates duplicate filter types", () => {
+      const input =
+        "kind:AITrainingBatch,AnalyzeTextCorpus kind:Chaos priority:2";
+      const result = consolidateFiltersText(input);
+      expect(result).toBe(
+        "kind:AITrainingBatch,AnalyzeTextCorpus,Chaos priority:2",
+      );
+    });
+
+    it("sorts values within consolidated filters", () => {
+      const input = "kind:zebra kind:alpha kind:batch";
+      const result = consolidateFiltersText(input);
+      expect(result).toBe("kind:alpha,batch,zebra");
+    });
+
+    it("handles multiple filter types with duplicates", () => {
+      const input = "kind:batch queue:high kind:stream queue:low priority:1";
+      const result = consolidateFiltersText(input);
+      expect(result).toBe("kind:batch,stream queue:high,low priority:1");
+    });
+
+    it("preserves order of first appearance of filter types", () => {
+      const input = "queue:high kind:batch queue:low";
+      const result = consolidateFiltersText(input);
+      expect(result).toBe("queue:high,low kind:batch");
+    });
+
+    it("removes duplicate values within the same filter type", () => {
+      const input = "kind:batch,stream kind:batch";
+      const result = consolidateFiltersText(input);
+      expect(result).toBe("kind:batch,stream");
+    });
+
+    it("handles empty input", () => {
+      const result = consolidateFiltersText("");
+      expect(result).toBe("");
+    });
+
+    it("handles input with no consolidation needed", () => {
+      const input = "kind:batch queue:priority";
+      const result = consolidateFiltersText(input);
+      expect(result).toBe("kind:batch queue:priority");
+    });
+  });
+
+  describe("analyzeAutocompleteContext", () => {
+    it("detects filter type context", () => {
+      const result = analyzeAutocompleteContext("ki", 2);
+      expect(result.type).toBe("filter-type");
+      expect(result.currentToken).toBe("ki");
+    });
+
+    it("detects filter value context", () => {
+      const result = analyzeAutocompleteContext("kind:bat", 8);
+      expect(result.type).toBe("filter-value");
+      expect(result.currentToken).toBe("bat");
+      expect(result.filterTypeId).toBe("kind");
+    });
+
+    it("respects suppression flag", () => {
+      const result = analyzeAutocompleteContext("ki", 2, true);
+      expect(result.type).toBe("none");
+    });
+  });
+
+  describe("applySuggestion", () => {
+    it("applies filter type suggestion", () => {
+      const result = applySuggestion("ki", 2, "kind", "filter-type");
+      expect(result.newText).toBe("kind:");
+      expect(result.newCursorPos).toBe(5);
+    });
+
+    it("applies filter value suggestion", () => {
+      const result = applySuggestion("kind:bat", 8, "batch", "filter-value");
+      expect(result.newText).toBe("kind:batch");
+      expect(result.newCursorPos).toBe(10);
+    });
+
+    it("applies filter value suggestion in comma-separated list", () => {
+      const result = applySuggestion(
+        "kind:batch,st",
+        13,
+        "stream",
+        "filter-value",
+      );
+      expect(result.newText).toBe("kind:batch,stream");
+      expect(result.newCursorPos).toBe(17);
+    });
+  });
+});

--- a/src/components/job-search/parser.ts
+++ b/src/components/job-search/parser.ts
@@ -1,0 +1,205 @@
+import { AVAILABLE_FILTERS, JobFilter, JobFilterTypeID } from "./types";
+
+/**
+ * Analyzes cursor position in filter text to determine what kind of autocomplete should be shown
+ */
+export function analyzeAutocompleteContext(
+  text: string,
+  cursorPos: number,
+  suppressSuggestions?: boolean,
+): {
+  currentToken?: string;
+  existingValues?: string[];
+  filterTypeId?: JobFilterTypeID;
+  type: "filter-type" | "filter-value" | "none";
+} {
+  // If suggestions are explicitly suppressed (e.g., just applied a suggestion), return none
+  if (suppressSuggestions) {
+    return { type: "none" };
+  }
+
+  const beforeCursor = text.substring(0, cursorPos);
+  const afterCursor = text.substring(cursorPos);
+
+  // Find the current "word" we're in by looking for spaces
+  const lastSpaceIndex = beforeCursor.lastIndexOf(" ");
+  const nextSpaceIndex = afterCursor.indexOf(" ");
+
+  const currentExpression = text.substring(
+    lastSpaceIndex + 1,
+    nextSpaceIndex === -1 ? text.length : cursorPos + nextSpaceIndex,
+  );
+
+  const colonIndex = currentExpression.indexOf(":");
+
+  if (colonIndex === -1) {
+    // We're typing a filter type
+    const currentToken = beforeCursor.substring(lastSpaceIndex + 1);
+    return {
+      currentToken,
+      type: "filter-type",
+    };
+  }
+
+  // We're after the colon, so we're typing filter values
+  const filterTypeStr = currentExpression
+    .substring(0, colonIndex)
+    .toLowerCase();
+  const filterType = AVAILABLE_FILTERS.find(
+    (f) => f.label === filterTypeStr || f.prefix === `${filterTypeStr}:`,
+  );
+
+  if (!filterType) {
+    return { type: "none" };
+  }
+
+  const valuesStr = currentExpression.substring(colonIndex + 1);
+  const existingValues = valuesStr
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+
+  // Find which value token the cursor is in
+  const valuesBeforeCursor = beforeCursor.substring(
+    beforeCursor.lastIndexOf(":") + 1,
+  );
+  const lastCommaIndex = valuesBeforeCursor.lastIndexOf(",");
+  const currentToken = valuesBeforeCursor.substring(lastCommaIndex + 1);
+
+  // Always show suggestions when in a filter value context, unless explicitly suppressed
+  return {
+    currentToken: currentToken.trim(),
+    existingValues: existingValues.filter((v) => v !== currentToken.trim()),
+    filterTypeId: filterType.id,
+    type: "filter-value",
+  };
+}
+
+/**
+ * Applies a suggestion at the current cursor position
+ */
+export function applySuggestion(
+  text: string,
+  cursorPos: number,
+  suggestion: string,
+  suggestionType: "filter-type" | "filter-value",
+): { newCursorPos: number; newText: string } {
+  const beforeCursor = text.substring(0, cursorPos);
+  const afterCursor = text.substring(cursorPos);
+
+  if (suggestionType === "filter-type") {
+    // Replace the current filter type token
+    const lastSpaceIndex = beforeCursor.lastIndexOf(" ");
+    const beforeToken = text.substring(0, lastSpaceIndex + 1);
+    const newText = `${beforeToken}${suggestion}:`;
+    const newCursorPos = newText.length;
+
+    return { newCursorPos, newText };
+  } else {
+    // Replace the current value token
+    const lastColonIndex = beforeCursor.lastIndexOf(":");
+    const valuesBeforeCursor = beforeCursor.substring(lastColonIndex + 1);
+    const lastCommaIndex = valuesBeforeCursor.lastIndexOf(",");
+
+    const beforeValueToken = beforeCursor.substring(
+      0,
+      lastColonIndex + 1 + lastCommaIndex + 1,
+    );
+
+    // Find the end of the current token
+    const nextCommaIndex = afterCursor.indexOf(",");
+    const nextSpaceIndex = afterCursor.indexOf(" ");
+    const tokenEnd = Math.min(
+      ...[nextCommaIndex, nextSpaceIndex].filter((i) => i !== -1),
+      afterCursor.length,
+    );
+
+    const afterToken = afterCursor.substring(tokenEnd);
+    const newText = `${beforeValueToken}${suggestion}${afterToken}`;
+    const newCursorPos = beforeValueToken.length + suggestion.length;
+
+    return { newCursorPos, newText };
+  }
+}
+
+/**
+ * Consolidates filters of the same type in the text input
+ * e.g., "kind:AITrainingBatch,AnalyzeTextCorpus kind:Chaos priority:2"
+ * becomes "kind:AITrainingBatch,AnalyzeTextCorpus,Chaos priority:2"
+ */
+export function consolidateFiltersText(text: string): string {
+  const filters = parseFiltersFromText(text);
+  return serializeFiltersToText(filters);
+}
+
+/**
+ * Converts a text string like "kind:batch,stream queue:priority" to an array of JobFilter objects
+ */
+export function parseFiltersFromText(text: string): JobFilter[] {
+  const filters: JobFilter[] = [];
+  const trimmedText = text.trim();
+
+  if (!trimmedText) {
+    return filters;
+  }
+
+  // Split by spaces to get individual filter expressions
+  const filterExpressions = trimmedText.split(/\s+/);
+
+  for (const expression of filterExpressions) {
+    const colonIndex = expression.indexOf(":");
+    if (colonIndex === -1) {
+      continue; // Skip invalid expressions without colons
+    }
+
+    const filterTypeStr = expression.substring(0, colonIndex).toLowerCase();
+    const valuesStr = expression.substring(colonIndex + 1);
+
+    // Find the matching filter type
+    const filterType = AVAILABLE_FILTERS.find(
+      (f) => f.label === filterTypeStr || f.prefix === `${filterTypeStr}:`,
+    );
+
+    if (!filterType) {
+      continue; // Skip unknown filter types
+    }
+
+    // Parse values (comma-separated)
+    const values = valuesStr
+      .split(",")
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+
+    // Check if we already have a filter of this type
+    const existingFilter = filters.find((f) => f.typeId === filterType.id);
+    if (existingFilter) {
+      // Merge values with existing filter, avoiding duplicates
+      const combinedValues = [...existingFilter.values, ...values];
+      existingFilter.values = Array.from(new Set(combinedValues)).sort();
+    } else {
+      // Create new filter
+      filters.push({
+        id: Math.random().toString(36).substr(2, 9),
+        prefix: filterType.prefix,
+        typeId: filterType.id,
+        values: Array.from(new Set(values)).sort(),
+      });
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Converts an array of JobFilter objects to a text string like "kind:batch,stream queue:priority"
+ */
+export function serializeFiltersToText(filters: JobFilter[]): string {
+  return filters
+    .filter((filter) => filter.values.length > 0)
+    .map((filter) => {
+      const typeLabel = filter.prefix.replace(":", "");
+      const valuesStr = filter.values.join(",");
+      return `${typeLabel}:${valuesStr}`;
+    })
+    .join(" ");
+}


### PR DESCRIPTION
This rewrites the newly added `JobSearch` component for filtering the `JobList`. This new approach uses a single underlying text input field and filters are built up as a single text string like:

    kind:Chaos,SendEmail priority:3

The same basic UX around autocomplete is still present, though the individual filter items no longer display as "tags" or "labels" and is instead a plain text input.

This provides cleaner keyboard navigation and a more natural feel for devs, including the ability to copy/paste the filter list. In the process, I also fixed a ton of implementation bugs and race conditions with the old implementation, including making the tests much more robust and reliable.


https://github.com/user-attachments/assets/6ebdfa02-4e8d-4b98-8209-7621ba6f3b93

Curious to hear your thoughts @brandur!