### PR TITLE
Reduce docker image size by removing Go debug symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY internal/ internal/
 COPY public/ public/
 COPY --from=build-ui /app/dist ./dist
 
+RUN go build -trimpath -ldflags="-w -s -buildid=" -o /bin/riverui ./cmd/riverui
 RUN go build -o /bin/riverui ./cmd/riverui
 
 FROM alpine:3.22.1


### PR DESCRIPTION
A minor `go build` change to trim the paths and remove some debug symbols without affecting `panic()`. This results in 7MB reduction in binary size

<img width="507" height="39" alt="image" src="https://github.com/user-attachments/assets/21bfe7b2-4d1a-4c5c-b61a-aa23a84e3d20" />
