### PR TITLE
Add postgres development database via docker compose

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,6 @@
 CORS_ORIGINS=http://localhost:5173,https://example.com
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/river_dev
+TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/river_dev
 OTEL_ENABLED=false
 PORT=8080
 VITE_RIVER_API_BASE_URL=http://localhost:8080/api

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,12 @@ verify: verify/sqlc
 .PHONY: verify/sqlc
 verify/sqlc:
 	cd internal/dbsqlc && sqlc diff
+
+.PHONY: db/up
+db/up:
+	docker compose -f docker-compose.dev.yaml down
+	docker compose -f docker-compose.dev.yaml up
+
+.PHONY: db/down
+db/down:
+	docker compose -f docker-compose.dev.yaml down

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,19 +1,18 @@
-name: riverui_dev
+name: riverui-dev
+
 services:
   postgres:
     image: "postgres:16-alpine"
     environment:
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=river_dev
       - POSTGRES_HOST_AUTH_METHOD=trust
     healthcheck:
-      test: [ "CMD", "pg_isready" ,"-d", "river_dev", "-U", "user" ]
+      test: [ "CMD", "pg_isready" ,"-d", "river_dev", "-U", "postgres" ]
       timeout: 20s
       retries: 10
       start_period: 3s
     volumes:
-      - postgres:/var/lib/postgresql/data
+      - ./scripts/docker-compose-dev/postgres/init:/docker-entrypoint-initdb.d
     ports:
       - "5432:5432"
   migrate:
@@ -22,7 +21,7 @@ services:
       postgres:
         condition: "service_healthy"
     entrypoint: "/bin/sh"
-    # cache the go binaries so they don't always download
+    # cache the go binaries so they don't redownload
     volumes:
       - gopath:/go
     command:
@@ -30,7 +29,9 @@ services:
       - |
         echo "downloading river binary"
         go install github.com/riverqueue/river/cmd/river@latest
+        echo "migrating river_dev database"
         river migrate-up --database-url "postgres://postgres:postgres@postgres/river_dev"
+        echo "migrating river_test database"
+        river migrate-up --database-url "postgres://postgres:postgres@postgres/river_test"
 volumes:
-  postgres:
   gopath:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -5,7 +5,7 @@ services:
     image: "postgres:16-alpine"
     environment:
       - POSTGRES_USER=postgres
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: [ "CMD", "pg_isready" ,"-d", "river_dev", "-U", "postgres" ]
       timeout: 20s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+name: riverui_dev
+services:
+  postgres:
+    image: "postgres:16-alpine"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=river_dev
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    healthcheck:
+      test: [ "CMD", "pg_isready" ,"-d", "river_dev", "-U", "user" ]
+      timeout: 20s
+      retries: 10
+      start_period: 3s
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  migrate:
+    image: "golang:1.24-alpine"
+    depends_on:
+      postgres:
+        condition: "service_healthy"
+    entrypoint: "/bin/sh"
+    # cache the go binaries so they don't always download
+    volumes:
+      - gopath:/go
+    command:
+      - -c
+      - |
+        echo "downloading river binary"
+        go install github.com/riverqueue/river/cmd/river@latest
+        river migrate-up --database-url "postgres://postgres:postgres@postgres/river_dev"
+volumes:
+  postgres:
+  gopath:

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,6 +34,13 @@ make dev
 
 By default the Go backend starts at http://localhost:8080 and the Vite React frontend starts at http://localhost:5173.
 
+## (Optional) Run the database via Docker Compose
+This option allows to skip migrating your local postgres database.
+It still assumes that port 5432 is free to use.
+```sh
+docker compose up
+```
+
 ## Migrate database
 
 ```sh

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,19 +34,24 @@ make dev
 
 By default the Go backend starts at http://localhost:8080 and the Vite React frontend starts at http://localhost:5173.
 
-## (Optional) Run the database via Docker Compose
-This option allows to skip migrating your local postgres database.
-It still assumes that port 5432 is free to use.
-```sh
-docker compose up
-```
-
 ## Migrate database
 
 ```sh
 $ createdb river_dev
 $ go install github.com/riverqueue/river/cmd/river
 $ river migrate-up --database-url postgres://localhost/river_dev
+```
+
+## Postgres with docker compose 
+If you decided to use postgres in docker compose, you can skip database migration steps for testing and development
+
+The database would be accessible through localhost
+```sh
+# start/restart
+make db/up
+
+# stop
+make db/down
 ```
 
 ## Run tests

--- a/scripts/docker-compose-dev/postgres/init/01-init.sql
+++ b/scripts/docker-compose-dev/postgres/init/01-init.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE river_dev;
+CREATE DATABASE river_test;


### PR DESCRIPTION
While working #390 I needed a local PostgreSQL instance to start the development server and run the tests.

It took me a while to figure out the database setup so I thought I should share this setup and document it.

I also added a "TEST_DATABASE_URL" variable to `env.local` to make it easy to run the tests. I recon it can interfere with current workflows, so I'm happy to remove it if necessary.