### PR TITLE
Tweaks for auth middleware tests: Focused + parallel + conventions

### DIFF
--- a/cmd/riverui/main.go
+++ b/cmd/riverui/main.go
@@ -163,7 +163,7 @@ func initServer(ctx context.Context, logger *slog.Logger, pathPrefix string) (*i
 		apimiddleware.MiddlewareFunc(logHandler),
 	)
 	if basicAuthUsername != "" && basicAuthPassword != "" {
-		middlewareStack.Use(&authMiddleware{username: basicAuthUsername, password: basicAuthPassword})
+		middlewareStack.Use(&authMiddleware{username: basicAuthUsername, password: basicAuthPassword, pathPrefix: pathPrefix})
 	}
 
 	return &initServerResult{


### PR DESCRIPTION
Follows up #390 with a couple tweaks for the tests:

* Make auth middleware tests more focused so they only test
  `authMiddleware` rather than the full server HTTP stack.

* Remove use of `t.Setenv` so we can run all tests in parallel.

* Use `pathPrefix` in middleware so that only the specific configured
  prefix is accepted rather than any prefix that might be present.

* Use `CamelCaseTestName` convention rather than "test name like this".

* Use `testBundle` convention for `setup`.