### PR TITLE
rename Server + ServerOpts to Handler + HandlerOpts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-⚠️ Version 0.12.0 has breaking changes when running `riverui` as an embedded `http.Handler` or via a Docker image. The `ghcr.io/riverqueue/riverui` images no longer include Pro-specific functionality; Pro customers must use new `riverqueue.com/riverproui` images to access Pro features. See details below.
+⚠️ Version 0.12.0 has breaking changes when running `riverui` as an embedded `http.Handler` or via a Docker image. The `ghcr.io/riverqueue/riverui` images no longer include Pro-specific functionality; Pro customers must use new `riverqueue.com/riverproui` images to access Pro features. The main type was also renamed from `Server` to `Handler` for correctness since it functions as an `http.Handler`. See details below.
 
 ### Changed
 
 - Go binary now built without debug symbols for a ~35% reduction in output size. [PR #391](https://github.com/riverqueue/riverui/pull/391).
 - **Breaking change:** River UI has been split into two modules and two executables: `riverui` for OSS-only functionality, and `riverproui` which adds Pro-specific functionality through dependencies on `riverqueue.com/riverpro`. This change makes it far easier to continue extending the UI for everybody but especially for Pro-specific feature.
 
-  Users who embed `riverui` into their Go app as a handler will need to update their `riverui.NewServer` initialization to provide requires an `Endpoints` option in `riverui.ServerOpts`, using `riverui.NewEndpoints(client, nil)` for the OSS `riverui` functionality or `riverproui.NewEndpoints(client, nil)` with a `riverpro.Client` for `riverpro` functionality:
+  As part of this, the `Server` and `ServerOpts` types were also renamed to
+  `Handler` and `HandlerOpts` respectievly.  Users who embed `riverui` into
+  their Go app as a handler will need to update their `riverui.NewServer`
+  initialization to `riverui.NewHandler` and to provide an `Endpoints` option in
+  `riverui.HandlerOpts`, using `riverui.NewEndpoints(client, nil)` for the OSS
+  `riverui` functionality or `riverproui.NewEndpoints(client, nil)` with a
+  `riverpro.Client` for `riverpro` functionality:
 
   ```go
-  server, err := riverui.NewServer(&riverui.ServerOpts{
+  handler, err := riverui.NewHandler(&riverui.HandlerOpts{
       // For OSS riverui:
       Endpoints: riverui.NewEndpoints(client, nil),
       // Or, for riverpro:
@@ -32,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   For users who directly run the published `riverui` executables (published as GitHub release artifacts), there are no `riverproui` equivalents; those who need one can build it directly from `riverproui/cmd/riverproui` in this repository. Alternatively, migrate to either the `riverqueue.com/riverproui` Docker images or embed the `http.Handler` in your app as shown above.
 
-  As part of this change, all database queries were removed from `riverui` in favor of being implemented directly in the underlying OSS and Pro drivers. [PR #379](https://github.com/riverqueue/riverui/pull/379).
+  As part of this change, all database queries were removed from `riverui` in favor of being implemented directly in the underlying OSS and Pro drivers. [PR #379](https://github.com/riverqueue/riverui/pull/379) and [PR 400](https://github.com/riverqueue/riverui/pull/400).
 
 - For job kind and queue name searching, match input against substrings instead of only prefixes. Particularly for long names, this is far more convenient. [PR #398](https://github.com/riverqueue/riverui/pull/398).
 

--- a/example_test.go
+++ b/example_test.go
@@ -18,10 +18,11 @@ import (
 	"github.com/riverqueue/river/rivershared/util/slogutil"
 )
 
-// ExampleNewServer demonstrates how to create a River UI server,
+// ExampleNewHandler demonstrates how to create a River UI handler,
 // embed it in an HTTP server, and make requests to its API endpoints.
-func ExampleNewServer() {
-	ctx := context.Background()
+func ExampleNewHandler() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Create a PostgreSQL connection pool. In a real application, you'd use your
 	// own connection string or pool config.
@@ -49,9 +50,9 @@ func ExampleNewServer() {
 		panic(err)
 	}
 
-	// Create the River UI server. This server implements http.Handler and can be
+	// Create the River UI handler. This handler implements http.Handler and can be
 	// mounted in an HTTP mux
-	server, err := riverui.NewServer(&riverui.ServerOpts{
+	handler, err := riverui.NewHandler(&riverui.HandlerOpts{
 		DevMode:   true, // Use the live filesystem—don't use this outside tests
 		Endpoints: riverui.NewEndpoints(client, nil),
 		Logger:    logger,
@@ -63,13 +64,13 @@ func ExampleNewServer() {
 
 	// Start the server to initialize background processes
 	// This does not start an HTTP server
-	if err := server.Start(ctx); err != nil {
+	if err := handler.Start(ctx); err != nil {
 		panic(err)
 	}
 
 	// Create an HTTP mux and mount the River UI:
 	mux := http.NewServeMux()
-	mux.Handle("/riverui/", server)
+	mux.Handle("/riverui/", handler)
 
 	// For this example, we use a test server to demonstrate API calls. In a
 	// production environment, you would use http.ListenAndServe instead.

--- a/handler_test.go
+++ b/handler_test.go
@@ -34,7 +34,7 @@ func TestNewHandlerIntegration(t *testing.T) {
 		t.Helper()
 
 		logger := riverinternaltest.Logger(t)
-		server, err := NewServer(&ServerOpts{
+		server, err := NewHandler(&HandlerOpts{
 			DevMode:     true,
 			Endpoints:   bundle,
 			LiveFS:      true,

--- a/internal/riveruicmd/riveruicmd_test.go
+++ b/internal/riveruicmd/riveruicmd_test.go
@@ -82,7 +82,7 @@ func TestInitServer(t *testing.T) {
 			initRes, _ := setup(t)
 			req := httptest.NewRequest(http.MethodGet, "/api/features", nil)
 			recorder := httptest.NewRecorder()
-			initRes.uiServer.ServeHTTP(recorder, req)
+			initRes.uiHandler.ServeHTTP(recorder, req)
 
 			var resp struct {
 				JobListHideArgsByDefault bool `json:"job_list_hide_args_by_default"`
@@ -98,7 +98,7 @@ func TestInitServer(t *testing.T) {
 			initRes, _ := setup(t)
 			req := httptest.NewRequest(http.MethodGet, "/api/features", nil)
 			recorder := httptest.NewRecorder()
-			initRes.uiServer.ServeHTTP(recorder, req)
+			initRes.uiHandler.ServeHTTP(recorder, req)
 
 			var resp struct {
 				JobListHideArgsByDefault bool `json:"job_list_hide_args_by_default"`
@@ -114,7 +114,7 @@ func TestInitServer(t *testing.T) {
 			initRes, _ := setup(t)
 			req := httptest.NewRequest(http.MethodGet, "/api/features", nil)
 			recorder := httptest.NewRecorder()
-			initRes.uiServer.ServeHTTP(recorder, req)
+			initRes.uiHandler.ServeHTTP(recorder, req)
 
 			var resp struct {
 				JobListHideArgsByDefault bool `json:"job_list_hide_args_by_default"`

--- a/riverproui/pro_handler_test.go
+++ b/riverproui/pro_handler_test.go
@@ -74,15 +74,15 @@ func TestProHandlerIntegration(t *testing.T) {
 		t.Helper()
 
 		logger := riverinternaltest.Logger(t)
-		opts := &riverui.ServerOpts{
+		opts := &riverui.HandlerOpts{
 			DevMode:   true,
 			Endpoints: bundle,
 			LiveFS:    false, // Disable LiveFS to avoid needing projectRoot
 			Logger:    logger,
 		}
-		server, err := riverui.NewServer(opts)
+		handler, err := riverui.NewHandler(opts)
 		require.NoError(t, err)
-		return server
+		return handler
 	}
 
 	testRunner := func(exec riverdriver.Executor, makeAPICall handlertest.APICallFunc) {


### PR DESCRIPTION
Although it must be "started" for its background caching routine to function, this type ultimately still functions as an `http.Handler` which can be embedded into an `http.ServeMux` or other handler-compatible router. It does _not_ function as an `http.Server` and the prior naming caused confusion in this regard.

Bite the bullet on the breaking rename while we already have other breaking changes going out for the endpoints concept.