### PR TITLE
avoid tag conflict with fetch-tags: true on docker release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "*" # TEMPORARY FOR TESTING
     tags:
       - "v*"
   pull_request:
@@ -269,10 +268,14 @@ jobs:
       manifest_digest: ${{ steps.manifest_digest.outputs.digest }}
       tag: ${{ steps.compute_tag.outputs.tag }}
     steps:
-      - name: Checkout
+      - name: Checkout full history (no tags yet)
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0 # full history
+          # keep fetch-tags off to avoid the conflict on tag events
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -438,7 +441,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0 # full history
+          # keep fetch-tags off to avoid the conflict on tag events
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Force refresh mutable tags
         if: startsWith(github.ref, 'refs/tags/riverproui/v')


### PR DESCRIPTION
From [this run](https://github.com/riverqueue/riverui/actions/runs/17013115497/job/48231882290):

```
  /usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules --depth=1 origin +aae662df012e279528f12d366b01a99acf3b1209:refs/tags/v0.12.0
  Error: fatal: Cannot fetch both aae662df012e279528f12d366b01a99acf3b1209 and refs/tags/v0.12.0 to refs/tags/v0.12.0
  Error: The process '/usr/bin/git' failed with exit code 128
```

This is an issue when using the `fetch-tags: true` option for a job triggered by a tag push, because the checkout action automatically fetches the current tag in that situation. The workaround is to fetch without that option using `depth: 0` and then later fetch all tags explicitly with `--force`