### PR TITLE
Add Schema parameter to API endpoint requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix autocomplete (job kind and queue name) failing with a `relation "river_job" does not exist` error when River tables are in a non-default schema. [PR #517](https://github.com/riverqueue/riverui/pull/517).
 - Workflow detail: add on-canvas zoom controls for click/touch navigation and improve controls styling for dark mode. [PR #524](https://github.com/riverqueue/riverui/pull/524).
 - Workflow detail: improve default workflow diagram framing for legibility while still allowing manual zoom-out to view the full graph. [PR #524](https://github.com/riverqueue/riverui/pull/524).
 - Workflow detail: truncate long workflow names in the header to prevent overflow and add a copy button for the full name. [PR #524](https://github.com/riverqueue/riverui/pull/524).

--- a/handler_api_endpoint.go
+++ b/handler_api_endpoint.go
@@ -114,6 +114,7 @@ func (a *autocompleteListEndpoint[TTx]) Execute(ctx context.Context, req *autoco
 				Exclude: req.Exclude,
 				Match:   match,
 				Max:     100,
+				Schema:  a.Client.Schema(),
 			})
 			if err != nil {
 				return nil, fmt.Errorf("error listing job kinds: %w", err)
@@ -133,6 +134,7 @@ func (a *autocompleteListEndpoint[TTx]) Execute(ctx context.Context, req *autoco
 				Exclude: req.Exclude,
 				Match:   match,
 				Max:     100,
+				Schema:  a.Client.Schema(),
 			})
 			if err != nil {
 				return nil, fmt.Errorf("error listing queue names: %w", err)

--- a/handler_api_endpoint_test.go
+++ b/handler_api_endpoint_test.go
@@ -174,6 +174,51 @@ func runAutocompleteTests(t *testing.T, facet autocompleteFacet, setupFunc func(
 		require.Len(t, resp.Data, 1)
 		require.Equal(t, "alpha_task", *resp.Data[0])
 	})
+
+	t.Run("WithNonDefaultSchema", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			logger = riversharedtest.Logger(t)
+			driver = riverpgxv5.New(riversharedtest.DBPool(ctx, t))
+		)
+
+		// DisableSchemaSharing is required because we need the schema name to configure the River client.
+		tx, schema := riverdbtest.TestTxPgxDriver(ctx, t, driver, &riverdbtest.TestTxOpts{DisableSchemaSharing: true})
+		exec := driver.UnwrapExecutor(tx)
+
+		client, err := river.NewClient(driver, &river.Config{
+			Logger: logger,
+			Schema: schema,
+		})
+		require.NoError(t, err)
+
+		endpoint := newAutocompleteListEndpoint(apibundle.APIBundle[pgx.Tx]{
+			Archetype:  riversharedtest.BaseServiceArchetype(t),
+			Client:     client,
+			DB:         exec,
+			Driver:     driver,
+			Extensions: func(_ context.Context) (map[string]bool, error) { return map[string]bool{}, nil },
+			Logger:     logger,
+		})
+
+		setupFunc(t, &setupEndpointTestBundle{client: client, exec: exec, logger: logger, tx: tx})
+
+		// Reset search_path to simulate production conditions where the connection
+		// doesn't include the River schema; unqualified table names would then fail.
+		_, err = tx.Exec(ctx, "SET search_path TO 'public'")
+		require.NoError(t, err)
+
+		resp, err := apitest.InvokeHandler(ctx, endpoint.Execute, testMountOpts(t), &autocompleteListRequest{
+			Facet: facet,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Data, 4)
+		require.Equal(t, "alpha_"+facet.baseString(), *resp.Data[0])
+		require.Equal(t, "alpha_task", *resp.Data[1])
+		require.Equal(t, "beta_"+facet.baseString(), *resp.Data[2])
+		require.Equal(t, "gamma_"+facet.baseString(), *resp.Data[3])
+	})
 }
 
 func (f autocompleteFacet) baseString() string {


### PR DESCRIPTION
I just noticed errors like

```
2026/02/27 17:20:40 ERROR error running API route error="error listing job kinds: ERROR: relation \"river_job\" does not exist (SQLSTATE 42P01)"
```

when using the autocomplete in the job list.

As this was my first hour using River, I just gave the error to Claude who immediately pointed out the inconsistencies between the 2 fixed methods (which did not pass the schema) and the others which do.

Depending on if you're fine with this, I could take more time later on to align this more with the repo style or add tests. Whatever is desired :)