### PR TITLE
Enable preformatting of job attempt logs

### DIFF
--- a/src/components/PlaintextPanel.tsx
+++ b/src/components/PlaintextPanel.tsx
@@ -124,9 +124,11 @@ export default function PlaintextPanel({
         className={styleConfig.content.base}
         style={styleConfig.content.layout}
       >
-        <code className={`${styleConfig.content.code} ${codeClassName || ""}`}>
-          {content}
-        </code>
+        <pre>
+          <code className={`${styleConfig.content.code} ${codeClassName || ""}`}>
+            {content}
+          </code>
+        </pre>
       </div>
     </div>
   );


### PR DESCRIPTION
I recognize that it's ill-advised to use the metadata to store lots of logs. However, the logs I do provide, I'd like to have control over the output for. The `<code>` block in the [PlaintextPanel][a] prevents any attempts at pre-formatting.

In the backend, these logs are glommed together as a single `[]byte` and that's fine, but upon output, that should make rendering the output of the `TextHandler` or `JSONHandler` easy; both of them separate records with newlines. With the use of a simple `<code>` tag, there's no way to perform any kind of formatting. It will strip it all.

This PR changes the PlainText component's `<code></code>` to a `<pre><code></code></pre>`, and I hope you'll consider approval.

[a]: https://github.com/riverqueue/riverui/blob/9df43c2f4f86cd726997ada749ac42e07be8b3f2/src/components/PlaintextPanel.tsx#L127-L129