### PR TITLE
fix Storybook dark preview background

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,3 +1,9 @@
-<html>
-  <body class="min-h-full bg-white dark:bg-slate-900"></body>
-</html>
+<style>
+  body {
+    min-height: 100%;
+    background-color: white;
+  }
+  .dark body {
+    background-color: var(--color-slate-900);
+  }
+</style>


### PR DESCRIPTION
Storybook's preview body file used nested `html` and `body` tags, but browsers discard that structure inside the preview iframe. As a result, dark-mode stories could render on the wrong background and make visual review misleading.

This replaces the invalid markup with a small style block that targets the actual preview `body`, including the root `.dark` class that Storybook applies for dark mode.