### PR TITLE
improve JobTimeline snoozed states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Job state sidebar: only highlight `Running` when the selected jobs state is actually running, even with retained search filters in the URL. [Fixes #526](https://github.com/riverqueue/riverui/issues/526). [PR #527](https://github.com/riverqueue/riverui/pull/527).
 - Job delete actions: require confirmation before deleting a single job or selected jobs in bulk. [Fixes #545](https://github.com/riverqueue/riverui/issues/545). [PR #546](https://github.com/riverqueue/riverui/pull/546).
 - Workflow detail: show the backend's not-found message instead of crashing when a workflow ID does not exist. [PR #564](https://github.com/riverqueue/riverui/pull/564).
+- Job detail: render a dedicated `Snoozed` timeline step for scheduled jobs with prior attempts so snoozed jobs no longer show negative wait durations. [PR #565](https://github.com/riverqueue/riverui/pull/565).
 
 ## [v0.15.0] - 2026-02-26
 

--- a/src/components/JobTimeline.test.tsx
+++ b/src/components/JobTimeline.test.tsx
@@ -1,0 +1,107 @@
+import { jobFactory } from "@test/factories/job";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import JobTimeline from "./JobTimeline";
+
+const NOW = new Date("2026-04-11T12:00:00.000Z");
+
+vi.mock("react-time-sync", () => ({
+  useTime: () => NOW.getTime() / 1000,
+}));
+
+const getStepItem = (name: string): HTMLLIElement => {
+  const stepItem = screen.getByText(name).closest("li");
+  if (!(stepItem instanceof HTMLLIElement)) {
+    throw new Error(`Expected ${name} step list item`);
+  }
+
+  return stepItem;
+};
+
+const getStepIcon = (name: string): HTMLSpanElement => {
+  const stepIcon = getStepItem(name).querySelector("span.absolute");
+  if (!(stepIcon instanceof HTMLSpanElement)) {
+    throw new Error(`Expected ${name} step icon`);
+  }
+
+  return stepIcon;
+};
+
+const getStepNames = (): string[] => {
+  return screen
+    .getAllByRole("heading", { level: 3 })
+    .map((heading) => heading.textContent ?? "");
+};
+
+describe("JobTimeline", () => {
+  it("renders snoozed jobs with a dedicated snoozed step after running", () => {
+    // This fixture models a job that already ran once, then was snoozed back
+    // into `scheduled`. In that state, the next retry time is known, but the
+    // original schedule/wait timing before the prior run is not.
+    const snoozedJob = jobFactory.scheduledSnoozed().build({
+      attemptedAt: new Date("2026-04-11T12:00:03.000Z"),
+      createdAt: NOW,
+      errors: [],
+      finalizedAt: undefined,
+      scheduledAt: new Date("2026-04-11T12:30:00.000Z"),
+    });
+
+    render(<JobTimeline job={snoozedJob} />);
+
+    expect(getStepNames()).toEqual([
+      "Created",
+      "Scheduled",
+      "Wait",
+      "Running",
+      "Snoozed",
+      "Complete",
+    ]);
+    expect(within(getStepItem("Scheduled")).getByText("—")).toBeInTheDocument();
+    expect(within(getStepItem("Wait")).getByText("—")).toBeInTheDocument();
+    expect(
+      within(getStepItem("Running")).queryByText("Not yet started"),
+    ).toBeNull();
+    expect(
+      within(getStepItem("Snoozed")).getByText(/Retrying/),
+    ).toBeInTheDocument();
+    expect(
+      within(getStepItem("Snoozed")).queryByText(/Job snoozed/i),
+    ).toBeNull();
+    expect(getStepIcon("Scheduled")).toHaveClass("bg-green-300");
+    expect(getStepIcon("Snoozed")).toHaveClass("bg-amber-200");
+    expect(screen.queryByText("-1h-30m-57s")).not.toBeInTheDocument();
+  });
+
+  it("keeps the regular scheduled timeline for jobs that have not run yet", () => {
+    const scheduledJob = jobFactory.scheduled().build({
+      createdAt: NOW,
+      scheduledAt: new Date("2026-04-11T12:30:00.000Z"),
+    });
+
+    render(<JobTimeline job={scheduledJob} />);
+
+    expect(getStepNames()).toEqual([
+      "Created",
+      "Scheduled",
+      "Wait",
+      "Running",
+      "Complete",
+    ]);
+    expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    expect(screen.getByText("Wait")).toBeInTheDocument();
+    expect(screen.queryByText("Snoozed")).not.toBeInTheDocument();
+    expect(getStepIcon("Scheduled")).toHaveClass("bg-amber-200");
+  });
+
+  it("keeps retryable jobs on the retry path instead of the snoozed path", () => {
+    const retryableJob = jobFactory.retryable().build({
+      scheduledAt: new Date("2026-04-11T12:30:00.000Z"),
+    });
+
+    render(<JobTimeline job={retryableJob} />);
+
+    expect(screen.getByText("Awaiting Retry")).toBeInTheDocument();
+    expect(screen.queryByText("Snoozed")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/JobTimeline.test.tsx
+++ b/src/components/JobTimeline.test.tsx
@@ -28,6 +28,15 @@ const getStepIcon = (name: string): HTMLSpanElement => {
   return stepIcon;
 };
 
+const getStepIconSVG = (name: string): SVGElement => {
+  const stepIconSVG = getStepIcon(name).querySelector("svg");
+  if (!(stepIconSVG instanceof SVGElement)) {
+    throw new Error(`Expected ${name} step icon SVG`);
+  }
+
+  return stepIconSVG;
+};
+
 const getStepNames = (): string[] => {
   return screen
     .getAllByRole("heading", { level: 3 })
@@ -103,5 +112,18 @@ describe("JobTimeline", () => {
 
     expect(screen.getByText("Awaiting Retry")).toBeInTheDocument();
     expect(screen.queryByText("Snoozed")).not.toBeInTheDocument();
+  });
+
+  it("uses distinct icons for completed running and complete steps", () => {
+    const completedJob = jobFactory.completed().build({
+      attemptedAt: new Date("2026-04-11T11:59:50.000Z"),
+      finalizedAt: new Date("2026-04-11T12:00:00.000Z"),
+    });
+
+    render(<JobTimeline job={completedJob} />);
+
+    expect(getStepIconSVG("Running").outerHTML).not.toEqual(
+      getStepIconSVG("Complete").outerHTML,
+    );
   });
 });

--- a/src/components/JobTimeline.tsx
+++ b/src/components/JobTimeline.tsx
@@ -11,7 +11,7 @@ import {
   QueueListIcon,
   TrashIcon,
   XCircleIcon,
-} from "@heroicons/react/24/outline";
+} from "@heroicons/react/24/solid";
 import { AttemptError, Job } from "@services/jobs";
 import { Heroicon, JobState } from "@services/types";
 import clsx from "clsx";
@@ -59,6 +59,7 @@ const StatusStep = ({
 }) => {
   const statusVerticalLineClasses = statusVerticalLineClassesFor(status);
   const statusIconClasses = statusIconClassesFor(status);
+  const iconColorClasses = statusIconColorClassesFor(status);
 
   return (
     <li
@@ -70,14 +71,11 @@ const StatusStep = ({
     >
       <span
         className={clsx(
-          "absolute -start-5 flex size-8 items-center justify-center rounded-full ring-4 ring-white dark:ring-gray-900",
+          "absolute -start-5 flex size-8 items-center justify-center rounded-full ring-4 ring-white dark:ring-slate-900",
           statusIconClasses,
         )}
       >
-        <Icon
-          aria-hidden="true"
-          className={clsx("size-5 text-slate-900 dark:text-white")}
-        />
+        <Icon aria-hidden="true" className={clsx("size-5", iconColorClasses)} />
       </span>
       <h3 className="ml-6 pt-1.5 leading-tight font-medium">{name}</h3>
       <p className="ml-6 text-sm" title={descriptionTitle}>
@@ -90,15 +88,15 @@ const StatusStep = ({
 const statusVerticalLineClassesFor = (status: StepStatus): string => {
   switch (status) {
     case "active":
-      return "before:border-gray-200 dark:before:border-gray-700";
+      return "before:border-slate-200 dark:before:border-slate-700";
     case "complete":
-      return "before:border-green-400 dark:before:border-green-900";
+      return "before:border-green-400 dark:before:border-green-800";
     case "failed":
-      return "before:border-red-200 dark:before:border-red-900";
+      return "before:border-red-200 dark:before:border-red-800";
     case "pending":
-      return "before:border-gray-200 dark:before:border-gray-700";
+      return "before:border-slate-200 dark:before:border-slate-700";
     case "waiting":
-      return "before:border-gray-200 dark:before:border-gray-700";
+      return "before:border-slate-200 dark:before:border-slate-700";
   }
   return "";
 };
@@ -112,9 +110,25 @@ const statusIconClassesFor = (status: StepStatus): string => {
     case "failed":
       return "bg-red-200 dark:bg-red-700";
     case "pending":
-      return "bg-gray-100 dark:bg-gray-700";
+      return "bg-slate-100 dark:bg-slate-700";
     case "waiting":
       return "bg-amber-200 dark:bg-amber-700";
+  }
+  return "";
+};
+
+const statusIconColorClassesFor = (status: StepStatus): string => {
+  switch (status) {
+    case "active":
+      return "text-blue-700 dark:text-blue-200";
+    case "complete":
+      return "text-green-800 dark:text-green-200";
+    case "failed":
+      return "text-red-700 dark:text-red-200";
+    case "pending":
+      return "text-slate-500 dark:text-slate-300";
+    case "waiting":
+      return "text-amber-700 dark:text-amber-200";
   }
   return "";
 };
@@ -427,7 +441,7 @@ type JobTimelineProps = {
 
 export default function JobTimeline({ job }: JobTimelineProps) {
   return (
-    <ol className="relative px-2 text-gray-500 sm:px-0 dark:text-gray-400">
+    <ol className="relative px-2 text-slate-500 sm:px-0 dark:text-slate-400">
       <StatusStep
         descriptionTitle={job.createdAt.toUTCString()}
         Icon={CircleStackIcon}

--- a/src/components/JobTimeline.tsx
+++ b/src/components/JobTimeline.tsx
@@ -29,7 +29,7 @@ const useRelativeFormattedTime = (time: Date, addSuffix: boolean): string => {
   return relative;
 };
 
-type StepStatus = "active" | "complete" | "failed" | "pending";
+type StepStatus = "active" | "complete" | "failed" | "pending" | "waiting";
 
 function RelativeTime({
   addSuffix = false,
@@ -96,6 +96,8 @@ const statusVerticalLineClassesFor = (status: StepStatus): string => {
       return "before:border-red-200 dark:before:border-red-900";
     case "pending":
       return "before:border-gray-200 dark:before:border-gray-700";
+    case "waiting":
+      return "before:border-gray-200 dark:before:border-gray-700";
   }
   return "";
 };
@@ -103,13 +105,15 @@ const statusVerticalLineClassesFor = (status: StepStatus): string => {
 const statusIconClassesFor = (status: StepStatus): string => {
   switch (status) {
     case "active":
-      return "bg-yellow-200 dark:bg-yellow-600";
+      return "bg-blue-200 dark:bg-blue-700";
     case "complete":
       return "bg-green-300 dark:bg-green-700";
     case "failed":
       return "bg-red-200 dark:bg-red-700";
     case "pending":
       return "bg-gray-100 dark:bg-gray-700";
+    case "waiting":
+      return "bg-amber-200 dark:bg-amber-700";
   }
   return "";
 };
@@ -121,7 +125,7 @@ const ScheduledStep = ({ job }: { job: Job }) => {
         descriptionTitle={job.scheduledAt.toUTCString()}
         Icon={ClockIcon}
         name="Scheduled"
-        status="active"
+        status="waiting"
       >
         <RelativeTime time={job.scheduledAt} />
       </StatusStep>
@@ -184,7 +188,7 @@ const WaitStep = ({ job }: { job: Job }) => {
 
   if (job.state === JobState.Available) {
     return (
-      <StatusStep Icon={QueueListIcon} name="Wait" status="active">
+      <StatusStep Icon={QueueListIcon} name="Wait" status="waiting">
         (<DurationCompact startTime={job.scheduledAt} />)
       </StatusStep>
     );
@@ -282,7 +286,7 @@ const RetryableStep = ({ job }: { job: Job }) => {
         descriptionTitle={job.scheduledAt.toUTCString()}
         Icon={ClockIcon}
         name="Awaiting Retry"
-        status="active"
+        status="waiting"
       >
         Job errored, retrying <RelativeTime addSuffix time={job.scheduledAt} />
       </StatusStep>

--- a/src/components/JobTimeline.tsx
+++ b/src/components/JobTimeline.tsx
@@ -29,6 +29,7 @@ const useRelativeFormattedTime = (time: Date, addSuffix: boolean): string => {
   return relative;
 };
 
+type SnoozedJob = { attemptedAt: Date } & Job;
 type StepStatus = "active" | "complete" | "failed" | "pending" | "waiting";
 
 function RelativeTime({
@@ -118,8 +119,39 @@ const statusIconClassesFor = (status: StepStatus): string => {
   return "";
 };
 
+// River jobs do not expose an explicit snooze flag, so we infer a snoozed job
+// from a scheduled future run that has already been attempted but neither errored
+// nor finalized. Manual retry from the UI transitions jobs to `available`, so it
+// should not hit this path.
+const isSnoozedJob = (job: Job, now: Date): job is SnoozedJob => {
+  return (
+    job.state === JobState.Scheduled &&
+    job.attemptedAt !== undefined &&
+    job.scheduledAt > now &&
+    job.finalizedAt === undefined &&
+    job.errors.length === 0
+  );
+};
+
 const ScheduledStep = ({ job }: { job: Job }) => {
-  if (job.state === JobState.Scheduled && job.scheduledAt > new Date()) {
+  const nowSec = useTime();
+  const now = useMemo(() => new Date(nowSec * 1000), [nowSec]);
+
+  if (isSnoozedJob(job, now)) {
+    return (
+      <StatusStep
+        descriptionTitle={job.scheduledAt.toUTCString()}
+        Icon={ClockIcon}
+        name="Scheduled"
+        status="complete"
+      >
+        {/* The next retry time is shown on `Snoozed`; the original schedule is lost. */}
+        —
+      </StatusStep>
+    );
+  }
+
+  if (job.state === JobState.Scheduled && job.scheduledAt > now) {
     return (
       <StatusStep
         descriptionTitle={job.scheduledAt.toUTCString()}
@@ -146,10 +178,21 @@ const ScheduledStep = ({ job }: { job: Job }) => {
 
 const WaitStep = ({ job }: { job: Job }) => {
   const nowSec = useTime();
-  const scheduledAtInFuture = useMemo(
-    () => job.scheduledAt >= new Date(nowSec * 1000),
-    [job.scheduledAt, nowSec],
-  );
+  const now = useMemo(() => new Date(nowSec * 1000), [nowSec]);
+  const scheduledAtInFuture = useMemo(() => job.scheduledAt >= now, [job, now]);
+
+  // A snooze overwrites `scheduledAt` with the next retry time, so the original
+  // wait duration before the prior run is not available anymore.
+  if (isSnoozedJob(job, now)) {
+    return (
+      <StatusStep
+        description="—"
+        Icon={QueueListIcon}
+        name="Wait"
+        status="complete"
+      />
+    );
+  }
 
   if (job.state === JobState.Scheduled && !job.attemptedAt) {
     return (
@@ -203,6 +246,22 @@ const WaitStep = ({ job }: { job: Job }) => {
 };
 
 const RunningStep = ({ job }: { job: Job }) => {
+  const nowSec = useTime();
+  const now = useMemo(() => new Date(nowSec * 1000), [nowSec]);
+
+  if (isSnoozedJob(job, now)) {
+    return (
+      <StatusStep
+        descriptionTitle={job.attemptedAt.toUTCString()}
+        Icon={RunningIcon}
+        name="Running"
+        status="complete"
+      >
+        <RelativeTime addSuffix={true} time={job.attemptedAt} />
+      </StatusStep>
+    );
+  }
+
   if (
     !job.attemptedAt ||
     job.state === JobState.Available ||
@@ -277,6 +336,24 @@ const RunningStep = ({ job }: { job: Job }) => {
       )}
     </StatusStep>
   );
+};
+
+const SnoozedStep = ({ job }: { job: Job }) => {
+  const nowSec = useTime();
+  const now = useMemo(() => new Date(nowSec * 1000), [nowSec]);
+
+  if (isSnoozedJob(job, now)) {
+    return (
+      <StatusStep
+        descriptionTitle={job.scheduledAt.toUTCString()}
+        Icon={ClockIcon}
+        name="Snoozed"
+        status="waiting"
+      >
+        Retrying <RelativeTime addSuffix time={job.scheduledAt} />
+      </StatusStep>
+    );
+  }
 };
 
 const RetryableStep = ({ job }: { job: Job }) => {
@@ -362,6 +439,7 @@ export default function JobTimeline({ job }: JobTimelineProps) {
       <ScheduledStep job={job} />
       <WaitStep job={job} />
       <RunningStep job={job} />
+      <SnoozedStep job={job} />
       <RetryableStep job={job} />
       <FinalizedStep job={job} />
     </ol>

--- a/src/components/JobTimeline.tsx
+++ b/src/components/JobTimeline.tsx
@@ -1,13 +1,11 @@
 import { DurationCompact } from "@components/DurationCompact";
-import {
-  RunningIcon,
-  RunningSpinnerIcon,
-} from "@components/icons/jobStateIcons";
+import { RunningSpinnerIcon } from "@components/icons/jobStateIcons";
 import {
   CheckCircleIcon,
   CircleStackIcon,
   ClockIcon,
   ExclamationCircleIcon,
+  PlayCircleIcon,
   QueueListIcon,
   TrashIcon,
   XCircleIcon,
@@ -267,7 +265,7 @@ const RunningStep = ({ job }: { job: Job }) => {
     return (
       <StatusStep
         descriptionTitle={job.attemptedAt.toUTCString()}
-        Icon={RunningIcon}
+        Icon={PlayCircleIcon}
         name="Running"
         status="complete"
       >
@@ -285,7 +283,7 @@ const RunningStep = ({ job }: { job: Job }) => {
     return (
       <StatusStep
         description="Not yet started"
-        Icon={RunningIcon}
+        Icon={PlayCircleIcon}
         name="Running"
         status="pending"
       />
@@ -314,7 +312,7 @@ const RunningStep = ({ job }: { job: Job }) => {
     const cancelledWhileRunning = Boolean(job.attemptedAt);
     const state = cancelledWhileRunning ? "complete" : "pending";
     return (
-      <StatusStep Icon={RunningIcon} name="Running" status={state}>
+      <StatusStep Icon={PlayCircleIcon} name="Running" status={state}>
         <RelativeTime addSuffix={true} time={job.attemptedAt} /> (
         <DurationCompact
           endTime={job.finalizedAt!}
@@ -336,7 +334,7 @@ const RunningStep = ({ job }: { job: Job }) => {
       descriptionTitle={
         errored ? lastError?.at.toUTCString() : job.attemptedAt.toUTCString()
       }
-      Icon={errored ? ExclamationCircleIcon : CheckCircleIcon}
+      Icon={errored ? ExclamationCircleIcon : PlayCircleIcon}
       name={errored ? "Errored" : "Running"}
       status={errored ? "failed" : "complete"}
     >

--- a/src/components/JobTimeline.tsx
+++ b/src/components/JobTimeline.tsx
@@ -1,6 +1,9 @@
 import { DurationCompact } from "@components/DurationCompact";
 import {
-  ArrowPathRoundedSquareIcon,
+  RunningIcon,
+  RunningSpinnerIcon,
+} from "@components/icons/jobStateIcons";
+import {
   CheckCircleIcon,
   CircleStackIcon,
   ClockIcon,
@@ -205,7 +208,7 @@ const RunningStep = ({ job }: { job: Job }) => {
     return (
       <StatusStep
         description="Not yet started"
-        Icon={ArrowPathRoundedSquareIcon}
+        Icon={RunningIcon}
         name="Running"
         status="pending"
       />
@@ -216,7 +219,7 @@ const RunningStep = ({ job }: { job: Job }) => {
     return (
       <StatusStep
         descriptionTitle={job.attemptedAt.toUTCString()}
-        Icon={ArrowPathRoundedSquareIcon}
+        Icon={RunningSpinnerIcon}
         name="Running"
         status="active"
       >
@@ -234,11 +237,7 @@ const RunningStep = ({ job }: { job: Job }) => {
     const cancelledWhileRunning = Boolean(job.attemptedAt);
     const state = cancelledWhileRunning ? "complete" : "pending";
     return (
-      <StatusStep
-        Icon={ArrowPathRoundedSquareIcon}
-        name="Running"
-        status={state}
-      >
+      <StatusStep Icon={RunningIcon} name="Running" status={state}>
         <RelativeTime addSuffix={true} time={job.attemptedAt} /> (
         <DurationCompact
           endTime={job.finalizedAt!}

--- a/src/components/TaskStateIcon.tsx
+++ b/src/components/TaskStateIcon.tsx
@@ -1,10 +1,10 @@
+import { RunningSpinnerIcon } from "@components/icons/jobStateIcons";
 import {
   CheckCircleIcon,
   ClockIcon,
   EllipsisHorizontalCircleIcon,
   ExclamationTriangleIcon,
   PauseCircleIcon,
-  PlayCircleIcon,
   QuestionMarkCircleIcon,
   XCircleIcon,
 } from "@heroicons/react/20/solid";
@@ -66,7 +66,7 @@ export const TaskStateIcon = ({
       );
     case JobState.Running:
       return (
-        <PlayCircleIcon
+        <RunningSpinnerIcon
           className={clsx(className, "text-yellow-500 dark:text-yellow-500")}
           {...sharedProps}
         />

--- a/src/components/icons/jobStateIcons.tsx
+++ b/src/components/icons/jobStateIcons.tsx
@@ -1,0 +1,88 @@
+import { forwardRef } from "react";
+
+type IconProps = {
+  title?: string;
+  titleId?: string;
+} & React.SVGProps<SVGSVGElement>;
+
+// Circumference of r=9 circle: 2π·9 ≈ 56.549
+// 75% arc (270°): 42.41, 25% gap: 14.14
+const SPINNER_R = 9;
+const SPINNER_DASH = "42.41 14.14";
+
+/**
+ * Animated ring spinner for the Running job state.
+ *
+ * Uses only CSS `transform: rotate()` for animation, which is composited
+ * entirely on the GPU — no layout or paint cost per frame.
+ */
+export const RunningSpinnerIcon = forwardRef<SVGSVGElement, IconProps>(
+  ({ title, titleId, ...props }, ref) => (
+    <svg
+      aria-hidden="true"
+      data-slot="icon"
+      fill="none"
+      ref={ref}
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      {title && <title id={titleId}>{title}</title>}
+      <circle
+        cx="12"
+        cy="12"
+        opacity="0.2"
+        r={SPINNER_R}
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <circle
+        className="origin-center animate-spin will-change-transform motion-reduce:animate-none"
+        cx="12"
+        cy="12"
+        r={SPINNER_R}
+        stroke="currentColor"
+        strokeDasharray={SPINNER_DASH}
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+    </svg>
+  ),
+);
+RunningSpinnerIcon.displayName = "RunningSpinnerIcon";
+
+/**
+ * Static ring indicator for non-active running steps (pending/completed).
+ * Same shape as RunningSpinnerIcon but without animation.
+ */
+export const RunningIcon = forwardRef<SVGSVGElement, IconProps>(
+  ({ title, titleId, ...props }, ref) => (
+    <svg
+      aria-hidden="true"
+      data-slot="icon"
+      fill="none"
+      ref={ref}
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      {title && <title id={titleId}>{title}</title>}
+      <circle
+        cx="12"
+        cy="12"
+        opacity="0.2"
+        r={SPINNER_R}
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        r={SPINNER_R}
+        stroke="currentColor"
+        strokeDasharray={SPINNER_DASH}
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+    </svg>
+  ),
+);
+RunningIcon.displayName = "RunningIcon";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "ignoreDeprecations": "6.0",
 
     /* Linting */
     "strict": true,
@@ -21,8 +22,9 @@
     "noFallthroughCasesInSwitch": true,
 
     // allow importing services by @services:
+    "baseUrl": "./src",
     "paths": {
-      "@*": ["./src/*"]
+      "@*": ["./*"]
     },
     "typeRoots": ["../../node_modules/@heroicons/**/*.d.ts"]
   },


### PR DESCRIPTION
Snoozed jobs were displayed as ordinary scheduled jobs even though they had already run once. Because snoozes overwrite `scheduled_at` with the next retry time, the timeline could show a negative wait duration and leave the prior run phase looking unstarted.

This treats inferred snoozed jobs as a distinct timeline phase. The original scheduled and wait timing are shown as unavailable, the prior run is marked complete, and the next retry appears in a dedicated `Snoozed` step.

The branch also tightens JobTimeline status colors and icons so waiting states use amber, active running uses blue, and completed running phases no longer share the same check icon as the final completion step.

| Change | Before | After |
| --- | --- | --- |
| Snoozed scheduled jobs no longer show a negative wait duration or an unstarted running phase. | <img width="360" height="330" alt="01-before-snoozed-job" src="https://github.com/user-attachments/assets/c84f563e-f10b-4d19-a675-42acb85500ed" /> | <img width="360" height="330" alt="01-after-snoozed-job" src="https://github.com/user-attachments/assets/1846f5e6-f95f-4878-9d18-e8f6867430cd" /> |
| Completed jobs use distinct icons for the running phase and final completion. | <img width="360" height="330" alt="02-before-completed-job-icons" src="https://github.com/user-attachments/assets/98f6fb7f-cd58-4251-a58e-5301251cfc38" /> | <img width="360" height="330" alt="02-after-completed-job-icons" src="https://github.com/user-attachments/assets/d86cbc67-43a9-438b-b477-003720ab39d3" /> |





