### PR TITLE
adjust workflow handle positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,12 @@
 
 ## Rules
 - No `any`; use `unknown` or specific types.
+- Avoid `as unknown as X` casts; prefer fixing the underlying type
+  (narrow props, export a type, add missing fields). If a cast is
+  truly necessary (e.g. testing malformed data, third-party type
+  workarounds), add a comment explaining why.
+- Prefer precise types over broad ones (`unknown[]`, `Record<string, unknown>`)
+  followed by casts at each access site. Type the data correctly at the source.
 - Tests live beside components (`.test.tsx`).
 - Prefix unused variables with `_`.
 

--- a/packager/packager.go
+++ b/packager/packager.go
@@ -78,6 +78,7 @@ func createBundle() error {
 
 	modFilename := version.Version + ".mod"
 	zipFilename := version.Version + ".zip"
+	infoFilename := version.Version + ".info"
 
 	modFileContents, err := os.ReadFile(filepath.Join(dir, "go.mod"))
 	if err != nil {
@@ -103,7 +104,7 @@ func createBundle() error {
 		Time:    timestamp,
 	}
 
-	infoFile, err := outputRoot.Create(version.Version + ".info")
+	infoFile, err := outputRoot.Create(infoFilename)
 	if err != nil {
 		return err
 	}

--- a/src/components/workflow-diagram/WorkflowNode.tsx
+++ b/src/components/workflow-diagram/WorkflowNode.tsx
@@ -38,7 +38,7 @@ const WorkflowNode = memo(
       >
         <Handle
           className={clsx(
-            "left-[-7px] size-4 border-4 border-slate-50 bg-slate-300 dark:border-slate-800 dark:bg-slate-600",
+            "left-px size-4 border-4 border-slate-50 bg-slate-300 dark:border-slate-800 dark:bg-slate-600",
             hasUpstreamDeps || "opacity-0",
           )}
           isConnectable={isConnectable}
@@ -48,7 +48,7 @@ const WorkflowNode = memo(
         />
         <Handle
           className={clsx(
-            "right-[-7px] size-4 border-4 border-slate-50 bg-slate-300 dark:border-slate-800 dark:bg-slate-600",
+            "right-px size-4 border-4 border-slate-50 bg-slate-300 dark:border-slate-800 dark:bg-slate-600",
             hasDownstreamDeps || "opacity-0",
           )}
           isConnectable={isConnectable}


### PR DESCRIPTION
Workflow diagram handles were positioned just outside node edges, which made connection dots feel offset from the cards they belong to. This moves the handles inward so they sit centered on the node edge while preserving the existing hidden-handle behavior for nodes without upstream or downstream dependencies.

| Before | After |
| - | - |
| <img width="639" height="164" alt="01-before-workflow-handle-positioning" src="https://github.com/user-attachments/assets/72c4931a-1f43-430b-956e-cc5be4f60fa3" /> | <img width="639" height="164" alt="02-after-workflow-handle-positioning" src="https://github.com/user-attachments/assets/3e8c7fa3-bbf9-44b8-b9f1-183dde29764a" /> |


This also adds local type-safety guidance for future agent edits, and a packager cleanup that reuses the computed `.info` filename instead of rebuilding it inline.