### PR TITLE
Override vulnerable shell-quote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7771,9 +7771,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "vitest": "^4.1.9"
   },
   "overrides": {
+    "shell-quote": "^1.9.0",
     "storybook": "$storybook"
   },
   "scripts": {


### PR DESCRIPTION
Dependabot cannot resolve the high-severity
`shell-quote` advisory because `concurrently@10.0.3` pins vulnerable
`shell-quote@1.8.4`; its only automatic path would downgrade
`concurrently`.

This adds a root override for the compatible patched release line, which
resolves `shell-quote@1.10.0` without changing `concurrently`. The lockfile
changes only that package's version, registry URL, and SHA-512 integrity.

The published artifacts and upstream source were reviewed before executing
project code. The patched package retains the same maintainers, publisher,
repository, signing key, license, and runtime surface, with no install hooks,
bins, native code, network access, or process execution.
