### PR TITLE
Bump brace-expansion from 5.0.7 to 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4982,16 +4982,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
Upgrades the dev-only transitive `brace-expansion` dependency from 5.0.7 to 5.0.8 through the existing `minimatch` range. Version 5.0.8 fixes [GHSA-mh99-v99m-4gvg](https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-mh99-v99m-4gvg), where chained brace groups can exhaust Node's memory and crash the process.

The patched release bounds total expansion length in addition to the existing result-count limit. The lockfile change is isolated to the package version, registry integrity, resolved artifact, and Node engine metadata; its Node 20+ floor is compatible with this repository's Node 24 requirement.