### PR TITLE
render JSON object keys correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Job args: preserve large numeric JSON values exactly when displaying and copying args, while keeping object keys sorted. [Fixes #593](https://github.com/riverqueue/riverui/issues/593). [PR #594](https://github.com/riverqueue/riverui/pull/594).
+- JSON viewer: render empty and escaped object property keys as valid JSON strings. [PR #632](https://github.com/riverqueue/riverui/pull/632).
 
 ## [v0.17.0] - 2026-07-31
 

--- a/src/components/JSONView.test.tsx
+++ b/src/components/JSONView.test.tsx
@@ -97,6 +97,19 @@ describe("JSONView Component", () => {
     expect(bravoBeforeZulu).toBeTruthy();
   });
 
+  it("renders empty and escaped object keys as valid JSON strings", () => {
+    const data = JSON.parse(
+      String.raw`{"":"empty key","quote\"key":"quoted key"}`,
+    ) as Record<string, unknown>;
+
+    render(<JSONView data={data} />);
+
+    expect(screen.getByText('""')).toBeInTheDocument();
+    expect(screen.getByText(String.raw`"quote\"key"`)).toBeInTheDocument();
+    expect(screen.getByText('"empty key"')).toBeInTheDocument();
+    expect(screen.getByText('"quoted key"')).toBeInTheDocument();
+  });
+
   it("renders nested JSON data with collapsed nodes but visible keys by default", () => {
     render(<JSONView data={nestedData} defaultExpandDepth={1} />);
 

--- a/src/components/JSONView.tsx
+++ b/src/components/JSONView.tsx
@@ -181,7 +181,7 @@ function JSONNodeRenderer({
   const color = styleConfig.json.key;
 
   // For primitive values, render key and value inline
-  if (propKey && isPrimitiveValue(data)) {
+  if (propKey !== null && isPrimitiveValue(data)) {
     return (
       <span
         style={{
@@ -191,7 +191,7 @@ function JSONNodeRenderer({
           whiteSpace: "nowrap",
         }}
       >
-        <span className={styleConfig.json.key}>&quot;{propKey}&quot;</span>
+        <span className={styleConfig.json.key}>{JSON.stringify(propKey)}</span>
         <span className={styleConfig.json.key}>:&nbsp;</span>
         {typeof data === "string" ? (
           <span className={valueColor("string")} style={{ whiteSpace: "pre" }}>
@@ -213,7 +213,7 @@ function JSONNodeRenderer({
   }
 
   // For non-primitive values (objects/arrays) or non-property values, use the normal rendering
-  if (!propKey) {
+  if (propKey === null) {
     return renderValue(
       data,
       valueColor,
@@ -234,7 +234,7 @@ function JSONNodeRenderer({
   if (count === 0) {
     return (
       <span>
-        <span style={{ color }}>&quot;{propKey}&quot;</span>
+        <span style={{ color }}>{JSON.stringify(propKey)}</span>
         <span style={{ color }}>:&nbsp;</span>
         <span>
           {isArray ? "[]" : "{}"}
@@ -294,7 +294,7 @@ function JSONNodeRenderer({
                 />
               )}
             </span>
-            <span style={{ color }}>&quot;{propKey}&quot;</span>
+            <span style={{ color }}>{JSON.stringify(propKey)}</span>
             <span style={{ color }}>:&nbsp;</span>
             <span>{isArray ? "[" : "{"}</span>
             {!open && (


### PR DESCRIPTION
`JSONView` currently treats property-key presence as a truthy check, so an empty-string key is rendered as though its value were at the root. Keys are also interpolated between quote characters without JSON escaping, which makes quotes and control characters display incorrectly.

This checks the existing null sentinel explicitly and renders keys with `JSON.stringify`, keeping empty and escaped property names visible as valid JSON strings.

Stacked on #594; the reviewable change is the single commit above that branch.