### PR TITLE
Upgrade golangci-lint to v2.13.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
     name: Go lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v2.11.4
+      GOLANGCI_LINT_VERSION: v2.13.1
       GOPROXY: https://proxy.golang.org,https://u:${{ secrets.RIVERPRO_GO_MOD_CREDENTIAL }}@riverqueue.com/goproxy,direct
     permissions:
       contents: read

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,11 +4,15 @@ linters:
   default: all
 
   disable:
+    # disabled because they have replacements enabled by default
+    - gomodguard # replaced by gomodguard_v2
+
     # disabled, but which we should enable with discussion
     - wrapcheck # checks that errors are wrapped; currently not done anywhere
 
     # disabled because we're not compliant, but which we should think about
     - exhaustruct # checks that properties in structs are exhaustively defined; may be a good idea
+    - exhaustruct_v5 # replacement for exhaustruct
     - testpackage # requires tests in test packages like `river_test`
 
     # disabled because they're annoying/bad
@@ -49,6 +53,9 @@ linters:
           pattern: \bmath\.Max\b
         - msg: Use built-in `min` function instead.
           pattern: \bmath\.Min\b
+
+    goconst:
+      ignore-tests: true
 
     gomoddirectives:
       replace-local: true

--- a/riverproui/internal/prohandler/pro_handler_api_endpoints.go
+++ b/riverproui/internal/prohandler/pro_handler_api_endpoints.go
@@ -706,7 +706,7 @@ func (req *workflowListRequest) ExtractRaw(r *http.Request) error {
 	}
 
 	if state := r.URL.Query().Get("state"); state != "" {
-		req.State = (state)
+		req.State = state
 	}
 
 	return nil


### PR DESCRIPTION
Upgrade golangci-lint from v2.11.4 to v2.13.1 so CI uses the current release with Go 1.27 support.

Align the all-linters configuration with the new replacement names: retire legacy `gomodguard` while leaving `gomodguard_v2` active, preserve the existing decision to disable exhaustive struct checks through `exhaustruct_v5`, and ignore repeated strings only in test fixtures. Apply the single `gofumpt` cleanup exposed by the upgrade.

The v2.13.1 signed tag, Go proxy source origin and checksums, published Linux archive checksum and contents, and release SBOM were reviewed as part of the upgrade.
