### PR TITLE
Prepare version v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.18.1] - 2026-08-23
+
 ### Changed
 
 - Update River Pro dependency to v0.27.2. [PR #663](https://github.com/riverqueue/riverui/pull/663).


### PR DESCRIPTION
Since no River UI changes were made here, I'll release both River UI and
River Pro UI point to the same commit.