### PR TITLE
Upgrade packager Go version to 1.26 + regression test

### DIFF
--- a/packager/go.mod
+++ b/packager/go.mod
@@ -1,7 +1,5 @@
 module riverqueue.com/riverqueue/packager
 
-go 1.25.0
-
-toolchain go1.25.7
+go 1.26.0
 
 require golang.org/x/mod v0.40.0

--- a/packager/go_version_test.go
+++ b/packager/go_version_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	goversion "go/version"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/mod/modfile"
+)
+
+func TestGoVersionCompatibleWithRiverUI(t *testing.T) {
+	t.Parallel()
+
+	var (
+		packagerGoVersion = goVersionFromModFile(t, "go.mod")
+		riverUIGoVersion  = goVersionFromModFile(t, filepath.Join("..", "go.mod"))
+	)
+
+	if goversion.Compare("go"+packagerGoVersion, "go"+riverUIGoVersion) < 0 {
+		t.Fatalf("packager Go version %s must be at least River UI Go version %s", packagerGoVersion, riverUIGoVersion)
+	}
+}
+
+func goVersionFromModFile(t *testing.T, path string) string {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("error reading %s: %v", path, err)
+	}
+
+	parsed, err := modfile.Parse(path, contents, nil)
+	if err != nil {
+		t.Fatalf("error parsing %s: %v", path, err)
+	}
+	if parsed.Go == nil {
+		t.Fatalf("%s has no Go version", path)
+	}
+
+	return parsed.Go.Version
+}


### PR DESCRIPTION
While trying to do a release yesterday, the final release build failed
unfortunately because `packager/go.mod` specified Go 1.25, and that was
too old to run the Go 1.26 found in `./go.mod`.

Here, upgrade the packager to Go 1.26, and also put in a test that'll
detect such a discrepancy in CI and fail on the branch rather than
failing only come release time, letting us catch the problem earlier and
avoid having to go back and fix up a release.